### PR TITLE
feat(clock): 時計表示と設定の永続化を実装する (#4)

### DIFF
--- a/adapters/preferences/src/main/java/io/github/hideyukimori/neneclock/adapter/preferences/PreferencesSettingsAdapter.java
+++ b/adapters/preferences/src/main/java/io/github/hideyukimori/neneclock/adapter/preferences/PreferencesSettingsAdapter.java
@@ -1,0 +1,123 @@
+package io.github.hideyukimori.neneclock.adapter.preferences;
+
+import io.github.hideyukimori.neneclock.application.SettingsLoadFailure;
+import io.github.hideyukimori.neneclock.application.SettingsLoadOutcome;
+import io.github.hideyukimori.neneclock.application.SettingsSaveFailure;
+import io.github.hideyukimori.neneclock.application.SettingsSaveOutcome;
+import io.github.hideyukimori.neneclock.application.SettingsStorePort;
+import io.github.hideyukimori.neneclock.domain.ClockFormat;
+import io.github.hideyukimori.neneclock.domain.DateVisibility;
+import io.github.hideyukimori.neneclock.domain.FontSize;
+import io.github.hideyukimori.neneclock.domain.FontSizeOutcome;
+import io.github.hideyukimori.neneclock.domain.SecondsVisibility;
+import io.github.hideyukimori.neneclock.domain.SettingsSchemaVersion;
+import io.github.hideyukimori.neneclock.domain.UserSettings;
+import io.github.hideyukimori.neneclock.domain.WindowTopmost;
+import java.util.Objects;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+import org.jspecify.annotations.Nullable;
+
+/** {@link Preferences} に設定を保存する {@link SettingsStorePort} の実装。 */
+public final class PreferencesSettingsAdapter implements SettingsStorePort {
+
+    private static final String KEY_SCHEMA = "schemaVersion";
+    private static final String KEY_CLOCK_FORMAT = "clockFormat";
+    private static final String KEY_SECONDS = "secondsVisibility";
+    private static final String KEY_DATE = "dateVisibility";
+    private static final String KEY_TOPMOST = "windowTopmost";
+    private static final String KEY_FONT_POINTS = "fontPoints";
+
+    private static final int SCHEMA_ABSENT = 0;
+    private static final int FONT_POINTS_ABSENT = -1;
+
+    private final Preferences node;
+
+    private PreferencesSettingsAdapter(Preferences node) {
+        this.node = Objects.requireNonNull(node, "node");
+    }
+
+    /** production の合成ルートが使う生成経路。 */
+    public static PreferencesSettingsAdapter userScoped() {
+        return new PreferencesSettingsAdapter(Preferences.userNodeForPackage(PreferencesSettingsAdapter.class));
+    }
+
+    /** 任意のノードで組み立てる。テストが専用ノードを渡すための経路。 */
+    public static PreferencesSettingsAdapter at(Preferences node) {
+        return new PreferencesSettingsAdapter(node);
+    }
+
+    @Override
+    public SettingsLoadOutcome load() {
+        int storedSchema = node.getInt(KEY_SCHEMA, SCHEMA_ABSENT);
+        if (storedSchema == SCHEMA_ABSENT) {
+            return new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.ABSENT);
+        }
+        if (storedSchema < 1 || !new SettingsSchemaVersion(storedSchema).isSupported()) {
+            return new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.UNSUPPORTED_SCHEMA);
+        }
+        return restore();
+    }
+
+    @Override
+    public SettingsSaveOutcome save(UserSettings settings) {
+        Objects.requireNonNull(settings, "settings");
+        node.putInt(KEY_SCHEMA, SettingsSchemaVersion.CURRENT.value());
+        node.put(KEY_CLOCK_FORMAT, settings.clockFormat().name());
+        node.put(KEY_SECONDS, settings.secondsVisibility().name());
+        node.put(KEY_DATE, settings.dateVisibility().name());
+        node.put(KEY_TOPMOST, settings.windowTopmost().name());
+        node.putInt(KEY_FONT_POINTS, settings.fontSize().points());
+        try {
+            node.flush();
+        } catch (BackingStoreException failure) {
+            return new SettingsSaveOutcome.Failed(SettingsSaveFailure.UNWRITABLE);
+        }
+        return new SettingsSaveOutcome.Saved();
+    }
+
+    private SettingsLoadOutcome restore() {
+        ClockFormat clockFormat = lookup(ClockFormat.values(), node.get(KEY_CLOCK_FORMAT, null));
+        if (clockFormat == null) {
+            return invalidValue();
+        }
+        SecondsVisibility seconds = lookup(SecondsVisibility.values(), node.get(KEY_SECONDS, null));
+        if (seconds == null) {
+            return invalidValue();
+        }
+        DateVisibility date = lookup(DateVisibility.values(), node.get(KEY_DATE, null));
+        if (date == null) {
+            return invalidValue();
+        }
+        WindowTopmost topmost = lookup(WindowTopmost.values(), node.get(KEY_TOPMOST, null));
+        if (topmost == null) {
+            return invalidValue();
+        }
+        FontSize fontSize = readFontSize();
+        if (fontSize == null) {
+            return invalidValue();
+        }
+        return new SettingsLoadOutcome.Restored(new UserSettings(clockFormat, seconds, date, topmost, fontSize));
+    }
+
+    private static SettingsLoadOutcome invalidValue() {
+        return new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.INVALID_VALUE);
+    }
+
+    private @Nullable FontSize readFontSize() {
+        int points = node.getInt(KEY_FONT_POINTS, FONT_POINTS_ABSENT);
+        return switch (FontSize.of(points)) {
+            case FontSizeOutcome.Accepted accepted -> accepted.value();
+            case FontSizeOutcome.Rejected outOfRange -> null;
+        };
+    }
+
+    private static <T extends Enum<T>> @Nullable T lookup(T[] candidates, @Nullable String stored) {
+        for (T candidate : candidates) {
+            if (candidate.name().equals(stored)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+}

--- a/adapters/preferences/src/main/java/io/github/hideyukimori/neneclock/adapter/preferences/package-info.java
+++ b/adapters/preferences/src/main/java/io/github/hideyukimori/neneclock/adapter/preferences/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * {@code java.util.prefs} に触れる唯一の場所（ARC-002 / ARC-009）。
+ *
+ * <p>保存形式は版を持つ。読めない版は既定値へ黙って落とすのではなく、
+ * {@link io.github.hideyukimori.neneclock.application.SettingsLoadFailure} として上へ返す。
+ */
+@NullMarked
+package io.github.hideyukimori.neneclock.adapter.preferences;
+
+import org.jspecify.annotations.NullMarked;

--- a/adapters/preferences/src/test/java/io/github/hideyukimori/neneclock/adapter/preferences/PreferencesSettingsAdapterTest.java
+++ b/adapters/preferences/src/test/java/io/github/hideyukimori/neneclock/adapter/preferences/PreferencesSettingsAdapterTest.java
@@ -1,0 +1,89 @@
+package io.github.hideyukimori.neneclock.adapter.preferences;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.hideyukimori.neneclock.application.SettingsLoadFailure;
+import io.github.hideyukimori.neneclock.application.SettingsLoadOutcome;
+import io.github.hideyukimori.neneclock.application.SettingsSaveOutcome;
+import io.github.hideyukimori.neneclock.domain.ClockFormat;
+import io.github.hideyukimori.neneclock.domain.DateVisibility;
+import io.github.hideyukimori.neneclock.domain.FontSize;
+import io.github.hideyukimori.neneclock.domain.SecondsVisibility;
+import io.github.hideyukimori.neneclock.domain.UserSettings;
+import io.github.hideyukimori.neneclock.domain.WindowTopmost;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PreferencesSettingsAdapterTest {
+
+    private static final String TEST_NODE = "io/github/hideyukimori/neneclock/test";
+
+    private Preferences node = Preferences.userRoot().node(TEST_NODE);
+
+    @BeforeEach
+    void createNode() throws BackingStoreException {
+        node = Preferences.userRoot().node(TEST_NODE);
+        node.clear();
+    }
+
+    @AfterEach
+    void removeNode() throws BackingStoreException {
+        node.removeNode();
+    }
+
+    @Test
+    void reportsAbsentSettingsOnFirstRun() {
+        SettingsLoadOutcome outcome = PreferencesSettingsAdapter.at(node).load();
+
+        assertThat(outcome).isEqualTo(new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.ABSENT));
+        assertThat(outcome.settingsOrDefaults()).isEqualTo(UserSettings.defaults());
+    }
+
+    @Test
+    void roundTripsSavedSettings() {
+        PreferencesSettingsAdapter adapter = PreferencesSettingsAdapter.at(node);
+        UserSettings stored = new UserSettings(
+                ClockFormat.HOUR_12,
+                SecondsVisibility.HIDDEN,
+                DateVisibility.HIDDEN,
+                WindowTopmost.ENABLED,
+                FontSize.DEFAULT);
+
+        SettingsSaveOutcome saveOutcome = adapter.save(stored);
+
+        assertThat(saveOutcome).isEqualTo(new SettingsSaveOutcome.Saved());
+        assertThat(adapter.load()).isEqualTo(new SettingsLoadOutcome.Restored(stored));
+    }
+
+    @Test
+    void refusesAnUnsupportedSchemaInsteadOfGuessing() {
+        node.putInt("schemaVersion", 99);
+
+        SettingsLoadOutcome outcome = PreferencesSettingsAdapter.at(node).load();
+
+        assertThat(outcome).isEqualTo(new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.UNSUPPORTED_SCHEMA));
+    }
+
+    @Test
+    void refusesAnUnknownEnumValue() {
+        PreferencesSettingsAdapter.at(node).save(UserSettings.defaults());
+        node.put("clockFormat", "HOUR_13");
+
+        SettingsLoadOutcome outcome = PreferencesSettingsAdapter.at(node).load();
+
+        assertThat(outcome).isEqualTo(new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.INVALID_VALUE));
+    }
+
+    @Test
+    void refusesAFontSizeOutsideTheAllowedRange() {
+        PreferencesSettingsAdapter.at(node).save(UserSettings.defaults());
+        node.putInt("fontPoints", FontSize.MAXIMUM_POINTS + 1);
+
+        SettingsLoadOutcome outcome = PreferencesSettingsAdapter.at(node).load();
+
+        assertThat(outcome).isEqualTo(new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.INVALID_VALUE));
+    }
+}

--- a/adapters/system-time/src/main/java/io/github/hideyukimori/neneclock/adapter/systemtime/SystemWallClockAdapter.java
+++ b/adapters/system-time/src/main/java/io/github/hideyukimori/neneclock/adapter/systemtime/SystemWallClockAdapter.java
@@ -1,0 +1,41 @@
+package io.github.hideyukimori.neneclock.adapter.systemtime;
+
+import io.github.hideyukimori.neneclock.application.WallClockPort;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Objects;
+
+/**
+ * システム時計から現在時刻を読む {@link WallClockPort} の実装。
+ *
+ * <p>アプリ全体で「実時刻を読む」のはこのクラスだけである。
+ */
+public final class SystemWallClockAdapter implements WallClockPort {
+
+    private final Clock clock;
+
+    private SystemWallClockAdapter(Clock clock) {
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    /**
+     * production の合成ルートが使う生成経路。
+     *
+     * <p>タイムゾーンの既定値を読むのもこの区画に閉じる。合成ルートへ漏らすと、
+     * 「環境を読む場所」が 2 つになる（ARC-007）。
+     */
+    public static SystemWallClockAdapter system() {
+        return new SystemWallClockAdapter(Clock.system(ZoneId.systemDefault()));
+    }
+
+    /** 任意の {@link Clock} で組み立てる。テストが固定時計を渡すための経路。 */
+    public static SystemWallClockAdapter using(Clock clock) {
+        return new SystemWallClockAdapter(clock);
+    }
+
+    @Override
+    public LocalDateTime currentDateTime() {
+        return LocalDateTime.now(clock);
+    }
+}

--- a/adapters/system-time/src/main/java/io/github/hideyukimori/neneclock/adapter/systemtime/package-info.java
+++ b/adapters/system-time/src/main/java/io/github/hideyukimori/neneclock/adapter/systemtime/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * 現在時刻を JDK から読める唯一の場所（ARC-007 の例外区画）。
+ *
+ * <p>このモジュールだけ {@code config/forbiddenapis/determinism.txt} を適用しない。
+ * ほかのモジュールで {@code now()} を書くとビルドが落ちる。
+ */
+@NullMarked
+package io.github.hideyukimori.neneclock.adapter.systemtime;
+
+import org.jspecify.annotations.NullMarked;

--- a/adapters/system-time/src/test/java/io/github/hideyukimori/neneclock/adapter/systemtime/SystemWallClockAdapterTest.java
+++ b/adapters/system-time/src/test/java/io/github/hideyukimori/neneclock/adapter/systemtime/SystemWallClockAdapterTest.java
@@ -1,0 +1,26 @@
+package io.github.hideyukimori.neneclock.adapter.systemtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+
+class SystemWallClockAdapterTest {
+
+    @Test
+    void readsTheInjectedClockRatherThanTheWallClock() {
+        Clock fixed = Clock.fixed(Instant.parse("2026-09-03T04:45:09Z"), ZoneId.of("UTC"));
+
+        LocalDateTime moment = SystemWallClockAdapter.using(fixed).currentDateTime();
+
+        assertThat(moment).isEqualTo(LocalDateTime.of(2026, 9, 3, 4, 45, 9));
+    }
+
+    @Test
+    void theProductionFactoryProducesAUsableAdapter() {
+        assertThat(SystemWallClockAdapter.system().currentDateTime()).isNotNull();
+    }
+}

--- a/app/src/main/java/io/github/hideyukimori/neneclock/app/NeNeClockApplication.java
+++ b/app/src/main/java/io/github/hideyukimori/neneclock/app/NeNeClockApplication.java
@@ -1,0 +1,38 @@
+package io.github.hideyukimori.neneclock.app;
+
+import io.github.hideyukimori.neneclock.adapter.preferences.PreferencesSettingsAdapter;
+import io.github.hideyukimori.neneclock.adapter.systemtime.SystemWallClockAdapter;
+import io.github.hideyukimori.neneclock.application.ClockFaceQuery;
+import io.github.hideyukimori.neneclock.application.SettingsStorePort;
+import io.github.hideyukimori.neneclock.domain.UserSettings;
+import io.github.hideyukimori.neneclock.ui.swing.ClockPanel;
+import io.github.hideyukimori.neneclock.ui.swing.ClockTicker;
+import io.github.hideyukimori.neneclock.ui.swing.MainFrame;
+import javax.swing.SwingUtilities;
+
+/** アプリケーションの入口。配線だけを行う。 */
+public final class NeNeClockApplication {
+
+    private NeNeClockApplication() {}
+
+    /** 起動する。すべての Swing 操作は EDT 上で行う（SWG-001）。 */
+    public static void main(String[] arguments) {
+        SwingUtilities.invokeLater(NeNeClockApplication::start);
+    }
+
+    private static void start() {
+        SettingsStorePort settingsStore = PreferencesSettingsAdapter.userScoped();
+        UserSettings settings = settingsStore.load().settingsOrDefaults();
+
+        ClockFaceQuery clockFace = new ClockFaceQuery(SystemWallClockAdapter.system());
+        ClockPanel clockPanel = new ClockPanel();
+        MainFrame frame = new MainFrame(clockPanel);
+
+        frame.renderSettings(settings);
+        clockPanel.renderFace(clockFace.currentFace(settings));
+
+        ClockTicker ticker = new ClockTicker(() -> clockPanel.renderFace(clockFace.currentFace(settings)));
+        ticker.start();
+        frame.display();
+    }
+}

--- a/app/src/main/java/io/github/hideyukimori/neneclock/app/package-info.java
+++ b/app/src/main/java/io/github/hideyukimori/neneclock/app/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * 合成ルート。ポートに実装を結び、UI を起動する（ARC-006）。
+ *
+ * <p>業務判断をこのパッケージに置かない。分岐が要るなら application 層へ移す。
+ */
+@NullMarked
+package io.github.hideyukimori.neneclock.app;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/application/src/main/java/io/github/hideyukimori/neneclock/application/ClockFace.java
+++ b/core/application/src/main/java/io/github/hideyukimori/neneclock/application/ClockFace.java
@@ -1,0 +1,14 @@
+package io.github.hideyukimori.neneclock.application;
+
+import java.util.Objects;
+
+/**
+ * 画面に出す文字列そのもの。UI はこれを描くだけで、整形の判断を持たない（ARC-011）。
+ */
+public record ClockFace(String time, DateLine date) {
+
+    public ClockFace {
+        Objects.requireNonNull(time, "time");
+        Objects.requireNonNull(date, "date");
+    }
+}

--- a/core/application/src/main/java/io/github/hideyukimori/neneclock/application/ClockFaceQuery.java
+++ b/core/application/src/main/java/io/github/hideyukimori/neneclock/application/ClockFaceQuery.java
@@ -1,0 +1,62 @@
+package io.github.hideyukimori.neneclock.application;
+
+import io.github.hideyukimori.neneclock.domain.UserSettings;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * 設定から表示文字列を作る唯一の経路（ARC-001）。
+ *
+ * <p>UI 側で {@code DateTimeFormatter} を組み立てることは ArchUnit が拒否する。整形規則が
+ * 2 か所に分かれると、表示のずれが「どちらが正しいか分からない」形で残るため。
+ */
+public final class ClockFaceQuery {
+
+    private static final DateTimeFormatter TIME_24_WITH_SECONDS = DateTimeFormatter.ofPattern("HH:mm:ss", Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_24_WITHOUT_SECONDS = DateTimeFormatter.ofPattern("HH:mm", Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_12_WITH_SECONDS =
+            DateTimeFormatter.ofPattern("hh:mm:ss a", Locale.ROOT);
+
+    private static final DateTimeFormatter TIME_12_WITHOUT_SECONDS =
+            DateTimeFormatter.ofPattern("hh:mm a", Locale.ROOT);
+
+    private static final DateTimeFormatter DATE = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT);
+
+    private final WallClockPort clock;
+
+    public ClockFaceQuery(WallClockPort clock) {
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    /** 現在時刻を設定に従って整形する。 */
+    public ClockFace currentFace(UserSettings settings) {
+        Objects.requireNonNull(settings, "settings");
+        LocalDateTime moment = clock.currentDateTime();
+        String time = timeFormatter(settings).format(moment);
+        DateLine date =
+                switch (settings.dateVisibility()) {
+                    case SHOWN -> new DateLine.Shown(DATE.format(moment));
+                    case HIDDEN -> new DateLine.Hidden();
+                };
+        return new ClockFace(time, date);
+    }
+
+    private static DateTimeFormatter timeFormatter(UserSettings settings) {
+        return switch (settings.clockFormat()) {
+            case HOUR_24 ->
+                switch (settings.secondsVisibility()) {
+                    case SHOWN -> TIME_24_WITH_SECONDS;
+                    case HIDDEN -> TIME_24_WITHOUT_SECONDS;
+                };
+            case HOUR_12 ->
+                switch (settings.secondsVisibility()) {
+                    case SHOWN -> TIME_12_WITH_SECONDS;
+                    case HIDDEN -> TIME_12_WITHOUT_SECONDS;
+                };
+        };
+    }
+}

--- a/core/application/src/main/java/io/github/hideyukimori/neneclock/application/DateLine.java
+++ b/core/application/src/main/java/io/github/hideyukimori/neneclock/application/DateLine.java
@@ -1,0 +1,21 @@
+package io.github.hideyukimori.neneclock.application;
+
+import java.util.Objects;
+
+/**
+ * 時計表示の日付行。
+ *
+ * <p>「非表示」を {@code null} や空文字で表すと意味が二重化するため、型で表す（JAV-004）。
+ */
+public sealed interface DateLine {
+
+    /** 日付を表示する。 */
+    record Shown(String text) implements DateLine {
+        public Shown {
+            Objects.requireNonNull(text, "text");
+        }
+    }
+
+    /** 日付を表示しない。 */
+    record Hidden() implements DateLine {}
+}

--- a/core/application/src/main/java/io/github/hideyukimori/neneclock/application/SettingsLoadFailure.java
+++ b/core/application/src/main/java/io/github/hideyukimori/neneclock/application/SettingsLoadFailure.java
@@ -1,0 +1,13 @@
+package io.github.hideyukimori.neneclock.application;
+
+/** 設定を復元できなかった理由。閉じた集合として扱う（ARC-010）。 */
+public enum SettingsLoadFailure {
+    /** 保存された設定がまだ無い（初回起動）。 */
+    ABSENT,
+    /** 保存領域を読めない。 */
+    UNREADABLE,
+    /** 保存された版をこのアプリが読めない（ARC-009）。 */
+    UNSUPPORTED_SCHEMA,
+    /** 保存された値が現在の不変条件を満たさない。 */
+    INVALID_VALUE
+}

--- a/core/application/src/main/java/io/github/hideyukimori/neneclock/application/SettingsLoadOutcome.java
+++ b/core/application/src/main/java/io/github/hideyukimori/neneclock/application/SettingsLoadOutcome.java
@@ -1,0 +1,40 @@
+package io.github.hideyukimori.neneclock.application;
+
+import io.github.hideyukimori.neneclock.domain.UserSettings;
+import java.util.Objects;
+
+/**
+ * 設定復元の結果。
+ *
+ * <p>「読めなかったら既定値へ落ちる」判断をこの型が 1 か所で持つ（ARC-001）。呼び出し側が
+ * 場当たりに {@code null} 判定や try/catch で代替値を作ることを防ぐ。
+ */
+public sealed interface SettingsLoadOutcome {
+
+    /** 復元できたか既定値かに関わらず、実際に使う設定。 */
+    UserSettings settingsOrDefaults();
+
+    /** 保存された設定を復元できた。 */
+    record Restored(UserSettings settings) implements SettingsLoadOutcome {
+        public Restored {
+            Objects.requireNonNull(settings, "settings");
+        }
+
+        @Override
+        public UserSettings settingsOrDefaults() {
+            return settings;
+        }
+    }
+
+    /** 復元できなかったので既定値を使う。理由は失われない。 */
+    record Defaulted(SettingsLoadFailure failure) implements SettingsLoadOutcome {
+        public Defaulted {
+            Objects.requireNonNull(failure, "failure");
+        }
+
+        @Override
+        public UserSettings settingsOrDefaults() {
+            return UserSettings.defaults();
+        }
+    }
+}

--- a/core/application/src/main/java/io/github/hideyukimori/neneclock/application/SettingsSaveFailure.java
+++ b/core/application/src/main/java/io/github/hideyukimori/neneclock/application/SettingsSaveFailure.java
@@ -1,0 +1,7 @@
+package io.github.hideyukimori.neneclock.application;
+
+/** 設定を保存できなかった理由。閉じた集合として扱う（ARC-010）。 */
+public enum SettingsSaveFailure {
+    /** 保存領域へ書けない。 */
+    UNWRITABLE
+}

--- a/core/application/src/main/java/io/github/hideyukimori/neneclock/application/SettingsSaveOutcome.java
+++ b/core/application/src/main/java/io/github/hideyukimori/neneclock/application/SettingsSaveOutcome.java
@@ -1,0 +1,22 @@
+package io.github.hideyukimori.neneclock.application;
+
+import java.util.Objects;
+
+/**
+ * 設定保存の結果。
+ *
+ * <p>保存の失敗を戻り値の無い {@code void} で消さない。呼び出し側が利用者へ知らせる判断を
+ * できるよう、型で返す（JAV-005）。
+ */
+public sealed interface SettingsSaveOutcome {
+
+    /** 保存できた。 */
+    record Saved() implements SettingsSaveOutcome {}
+
+    /** 保存できなかった。 */
+    record Failed(SettingsSaveFailure reason) implements SettingsSaveOutcome {
+        public Failed {
+            Objects.requireNonNull(reason, "reason");
+        }
+    }
+}

--- a/core/application/src/main/java/io/github/hideyukimori/neneclock/application/SettingsStorePort.java
+++ b/core/application/src/main/java/io/github/hideyukimori/neneclock/application/SettingsStorePort.java
@@ -1,0 +1,18 @@
+package io.github.hideyukimori.neneclock.application;
+
+import io.github.hideyukimori.neneclock.domain.UserSettings;
+
+/**
+ * 設定の永続化の唯一の窓口（ARC-002）。
+ *
+ * <p>production の実装は {@code :adapters:preferences} にただ 1 つ。UI から
+ * {@code java.util.prefs} を直接触ることは ArchUnit が拒否する。
+ */
+public interface SettingsStorePort {
+
+    /** 保存された設定を読む。失敗は例外ではなく結果型で返る（JAV-005）。 */
+    SettingsLoadOutcome load();
+
+    /** 設定を保存する。失敗は例外ではなく結果型で返る（JAV-005）。 */
+    SettingsSaveOutcome save(UserSettings settings);
+}

--- a/core/application/src/main/java/io/github/hideyukimori/neneclock/application/WallClockPort.java
+++ b/core/application/src/main/java/io/github/hideyukimori/neneclock/application/WallClockPort.java
@@ -1,0 +1,16 @@
+package io.github.hideyukimori.neneclock.application;
+
+import java.time.LocalDateTime;
+
+/**
+ * 壁時計の唯一の窓口（ARC-007）。
+ *
+ * <p>production の実装は {@code :adapters:system-time} にただ 1 つ。テストは固定値を返す実装を渡す。
+ * これ以外の経路で現在時刻を読むことは forbidden-apis が拒否する。
+ */
+@FunctionalInterface
+public interface WallClockPort {
+
+    /** 現在のローカル日時。 */
+    LocalDateTime currentDateTime();
+}

--- a/core/application/src/main/java/io/github/hideyukimori/neneclock/application/package-info.java
+++ b/core/application/src/main/java/io/github/hideyukimori/neneclock/application/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * 振る舞いの調整層。ポートを宣言し、その実装は知らない（ARC-002）。
+ *
+ * <p>時刻の入手は {@link io.github.hideyukimori.neneclock.application.WallClockPort} 経由のみ。
+ * Swing・java.util.prefs・ファイル・ネットワークをこのパッケージから触らない。
+ */
+@NullMarked
+package io.github.hideyukimori.neneclock.application;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/application/src/test/java/io/github/hideyukimori/neneclock/application/ClockFaceQueryTest.java
+++ b/core/application/src/test/java/io/github/hideyukimori/neneclock/application/ClockFaceQueryTest.java
@@ -1,0 +1,75 @@
+package io.github.hideyukimori.neneclock.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.hideyukimori.neneclock.domain.ClockFormat;
+import io.github.hideyukimori.neneclock.domain.DateVisibility;
+import io.github.hideyukimori.neneclock.domain.FontSize;
+import io.github.hideyukimori.neneclock.domain.SecondsVisibility;
+import io.github.hideyukimori.neneclock.domain.UserSettings;
+import io.github.hideyukimori.neneclock.domain.WindowTopmost;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class ClockFaceQueryTest {
+
+    private static final LocalDateTime AFTERNOON = LocalDateTime.of(2026, 9, 3, 13, 45, 9);
+
+    private final ClockFaceQuery query = new ClockFaceQuery(() -> AFTERNOON);
+
+    @Test
+    void formatsTwentyFourHourTimeWithSeconds() {
+        ClockFace face =
+                query.currentFace(settings(ClockFormat.HOUR_24, SecondsVisibility.SHOWN, DateVisibility.SHOWN));
+
+        assertThat(face.time()).isEqualTo("13:45:09");
+        assertThat(face.date()).isEqualTo(new DateLine.Shown("2026-09-03"));
+    }
+
+    @Test
+    void formatsTwentyFourHourTimeWithoutSeconds() {
+        ClockFace face =
+                query.currentFace(settings(ClockFormat.HOUR_24, SecondsVisibility.HIDDEN, DateVisibility.SHOWN));
+
+        assertThat(face.time()).isEqualTo("13:45");
+    }
+
+    @Test
+    void formatsTwelveHourTimeWithSeconds() {
+        ClockFace face =
+                query.currentFace(settings(ClockFormat.HOUR_12, SecondsVisibility.SHOWN, DateVisibility.SHOWN));
+
+        assertThat(face.time()).isEqualTo("01:45:09 PM");
+    }
+
+    @Test
+    void formatsTwelveHourTimeWithoutSeconds() {
+        ClockFace face =
+                query.currentFace(settings(ClockFormat.HOUR_12, SecondsVisibility.HIDDEN, DateVisibility.SHOWN));
+
+        assertThat(face.time()).isEqualTo("01:45 PM");
+    }
+
+    @Test
+    void hidesTheDateLineWhenTheSettingSaysSo() {
+        ClockFace face =
+                query.currentFace(settings(ClockFormat.HOUR_24, SecondsVisibility.SHOWN, DateVisibility.HIDDEN));
+
+        assertThat(face.date()).isEqualTo(new DateLine.Hidden());
+    }
+
+    @Test
+    void readsTheClockOnEveryCall() {
+        LocalDateTime[] moments = {AFTERNOON, AFTERNOON.plusSeconds(1)};
+        int[] calls = {0};
+        ClockFaceQuery advancing = new ClockFaceQuery(() -> moments[calls[0]++]);
+        UserSettings settings = settings(ClockFormat.HOUR_24, SecondsVisibility.SHOWN, DateVisibility.SHOWN);
+
+        assertThat(advancing.currentFace(settings).time()).isEqualTo("13:45:09");
+        assertThat(advancing.currentFace(settings).time()).isEqualTo("13:45:10");
+    }
+
+    private static UserSettings settings(ClockFormat format, SecondsVisibility seconds, DateVisibility date) {
+        return new UserSettings(format, seconds, date, WindowTopmost.DISABLED, FontSize.DEFAULT);
+    }
+}

--- a/core/application/src/test/java/io/github/hideyukimori/neneclock/application/SettingsLoadOutcomeTest.java
+++ b/core/application/src/test/java/io/github/hideyukimori/neneclock/application/SettingsLoadOutcomeTest.java
@@ -1,0 +1,44 @@
+package io.github.hideyukimori.neneclock.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.hideyukimori.neneclock.domain.ClockFormat;
+import io.github.hideyukimori.neneclock.domain.DateVisibility;
+import io.github.hideyukimori.neneclock.domain.FontSize;
+import io.github.hideyukimori.neneclock.domain.SecondsVisibility;
+import io.github.hideyukimori.neneclock.domain.UserSettings;
+import io.github.hideyukimori.neneclock.domain.WindowTopmost;
+import org.junit.jupiter.api.Test;
+
+class SettingsLoadOutcomeTest {
+
+    @Test
+    void restoredOutcomeKeepsTheStoredSettings() {
+        UserSettings stored = new UserSettings(
+                ClockFormat.HOUR_12,
+                SecondsVisibility.HIDDEN,
+                DateVisibility.HIDDEN,
+                WindowTopmost.ENABLED,
+                FontSize.DEFAULT);
+
+        SettingsLoadOutcome outcome = new SettingsLoadOutcome.Restored(stored);
+
+        assertThat(outcome.settingsOrDefaults()).isEqualTo(stored);
+    }
+
+    @Test
+    void defaultedOutcomeFallsBackWithoutLosingTheReason() {
+        SettingsLoadOutcome outcome = new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.UNSUPPORTED_SCHEMA);
+
+        assertThat(outcome.settingsOrDefaults()).isEqualTo(UserSettings.defaults());
+        assertThat(((SettingsLoadOutcome.Defaulted) outcome).failure())
+                .isEqualTo(SettingsLoadFailure.UNSUPPORTED_SCHEMA);
+    }
+
+    @Test
+    void saveOutcomeDistinguishesSuccessFromFailure() {
+        assertThat(new SettingsSaveOutcome.Saved()).isEqualTo(new SettingsSaveOutcome.Saved());
+        assertThat(new SettingsSaveOutcome.Failed(SettingsSaveFailure.UNWRITABLE))
+                .isNotEqualTo(new SettingsSaveOutcome.Saved());
+    }
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/ClockFormat.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/ClockFormat.java
@@ -1,0 +1,9 @@
+package io.github.hideyukimori.neneclock.domain;
+
+/** 時刻表記。12 時間制と 24 時間制の 2 つしかない閉じた選択肢（JAV-002）。 */
+public enum ClockFormat {
+    /** 24 時間表記（既定）。 */
+    HOUR_24,
+    /** 12 時間表記。午前・午後の表示を伴う。 */
+    HOUR_12
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/DateVisibility.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/DateVisibility.java
@@ -1,0 +1,9 @@
+package io.github.hideyukimori.neneclock.domain;
+
+/** 日付行の表示可否。boolean ではなく列挙で表す（JAV-002）。 */
+public enum DateVisibility {
+    /** 日付を表示する。 */
+    SHOWN,
+    /** 日付を表示しない。 */
+    HIDDEN
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontSize.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontSize.java
@@ -1,0 +1,64 @@
+package io.github.hideyukimori.neneclock.domain;
+
+/**
+ * 表示フォントの大きさ（ポイント）。
+ *
+ * <p>コンストラクタは非公開で、生成経路は {@link #of(int)} ただ 1 本（JAV-007）。
+ * 不正な値は例外ではなく {@link FontSizeOutcome} で返す。
+ */
+public final class FontSize {
+
+    /** 許容する下限。仕様 FR-041 の範囲と一致する。 */
+    public static final int MINIMUM_POINTS = 24;
+
+    /** 許容する上限。仕様 FR-041 の範囲と一致する。 */
+    public static final int MAXIMUM_POINTS = 160;
+
+    private static final int DEFAULT_POINTS = 64;
+
+    /**
+     * 既定値。
+     *
+     * <p>ここで {@link #of(int)} を通して結果型を開くと、到達し得ない「拒否側」の分岐が残る。
+     * 到達しない防御コードを置くより、範囲内であることをテストで示すほうがこのリポジトリの
+     * 規律に合う（QLT-008 / QLT-009）。不変条件は {@code FontSizeTest} が保証している。
+     */
+    public static final FontSize DEFAULT = new FontSize(DEFAULT_POINTS);
+
+    private final int points;
+
+    private FontSize(int points) {
+        this.points = points;
+    }
+
+    /** 範囲を検証して生成する。ここが唯一の生成経路。 */
+    public static FontSizeOutcome of(int points) {
+        if (points < MINIMUM_POINTS) {
+            return new FontSizeOutcome.Rejected(FontSizeRejection.BELOW_MINIMUM);
+        }
+        if (points > MAXIMUM_POINTS) {
+            return new FontSizeOutcome.Rejected(FontSizeRejection.ABOVE_MAXIMUM);
+        }
+        return new FontSizeOutcome.Accepted(new FontSize(points));
+    }
+
+    /** ポイント数。 */
+    public int points() {
+        return points;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof FontSize size && size.points == points;
+    }
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(points);
+    }
+
+    @Override
+    public String toString() {
+        return "FontSize[" + points + "]";
+    }
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontSizeOutcome.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontSizeOutcome.java
@@ -1,0 +1,25 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import java.util.Objects;
+
+/**
+ * {@link FontSize} 生成の結果。
+ *
+ * <p>期待される失敗を例外ではなく型で表す（JAV-005）。呼び出し側は switch で網羅する。
+ */
+public sealed interface FontSizeOutcome {
+
+    /** 検証を通った値。 */
+    record Accepted(FontSize value) implements FontSizeOutcome {
+        public Accepted {
+            Objects.requireNonNull(value, "value");
+        }
+    }
+
+    /** 検証で拒否された。理由は閉じた集合で示す。 */
+    record Rejected(FontSizeRejection reason) implements FontSizeOutcome {
+        public Rejected {
+            Objects.requireNonNull(reason, "reason");
+        }
+    }
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontSizeRejection.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontSizeRejection.java
@@ -1,0 +1,9 @@
+package io.github.hideyukimori.neneclock.domain;
+
+/** フォントサイズが拒否された理由。呼び出し側が分岐できるよう、閉じた集合にする（ARC-010）。 */
+public enum FontSizeRejection {
+    /** 下限未満だった。 */
+    BELOW_MINIMUM,
+    /** 上限を超えていた。 */
+    ABOVE_MAXIMUM
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/SecondsVisibility.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/SecondsVisibility.java
@@ -1,0 +1,9 @@
+package io.github.hideyukimori.neneclock.domain;
+
+/** 秒の表示可否。boolean ではなく列挙で表す（JAV-002）。 */
+public enum SecondsVisibility {
+    /** 秒を表示する。 */
+    SHOWN,
+    /** 秒を表示しない。 */
+    HIDDEN
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/SettingsSchemaVersion.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/SettingsSchemaVersion.java
@@ -1,0 +1,24 @@
+package io.github.hideyukimori.neneclock.domain;
+
+/**
+ * 永続化された設定のスキーマ版（ARC-009）。
+ *
+ * <p>版が上がるときは移行規則を同じ変更で持ち込む。読めない版は既定値へ落とすのではなく、
+ * 型のある失敗として上へ返す。
+ */
+public record SettingsSchemaVersion(int value) {
+
+    /** 現在アプリが書き出す版。 */
+    public static final SettingsSchemaVersion CURRENT = new SettingsSchemaVersion(1);
+
+    public SettingsSchemaVersion {
+        if (value < 1) {
+            throw new IllegalArgumentException("スキーマ版は 1 以上: " + value);
+        }
+    }
+
+    /** このアプリが読める版かどうか。 */
+    public boolean isSupported() {
+        return value == CURRENT.value;
+    }
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/UserSettings.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/UserSettings.java
@@ -1,0 +1,34 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import java.util.Objects;
+
+/**
+ * 利用者設定。すべて不変で、部分的に組み立てられない（JAV-003 / JAV-007）。
+ *
+ * <p>同じ事実を 2 か所に持たないため、表示に関する設定はこの 1 つの型だけが所有する（ARC-004）。
+ */
+public record UserSettings(
+        ClockFormat clockFormat,
+        SecondsVisibility secondsVisibility,
+        DateVisibility dateVisibility,
+        WindowTopmost windowTopmost,
+        FontSize fontSize) {
+
+    public UserSettings {
+        Objects.requireNonNull(clockFormat, "clockFormat");
+        Objects.requireNonNull(secondsVisibility, "secondsVisibility");
+        Objects.requireNonNull(dateVisibility, "dateVisibility");
+        Objects.requireNonNull(windowTopmost, "windowTopmost");
+        Objects.requireNonNull(fontSize, "fontSize");
+    }
+
+    /** 既定値。仕様 FR-040 と一致する。 */
+    public static UserSettings defaults() {
+        return new UserSettings(
+                ClockFormat.HOUR_24,
+                SecondsVisibility.SHOWN,
+                DateVisibility.SHOWN,
+                WindowTopmost.DISABLED,
+                FontSize.DEFAULT);
+    }
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/WindowTopmost.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/WindowTopmost.java
@@ -1,0 +1,9 @@
+package io.github.hideyukimori.neneclock.domain;
+
+/** 常に最前面に表示するかどうか。boolean ではなく列挙で表す（JAV-002）。 */
+public enum WindowTopmost {
+    /** 常に最前面に置く。 */
+    ENABLED,
+    /** 通常の重なり順に従う。 */
+    DISABLED
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/package-info.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * 意味の正本。時刻表示に関する値・不変条件・閉じた選択肢だけを持つ。
+ *
+ * <p>このパッケージは Swing・java.util.prefs・ファイル・現在時刻を知らない（ARC-003）。
+ */
+@NullMarked
+package io.github.hideyukimori.neneclock.domain;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/FontSizeTest.java
+++ b/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/FontSizeTest.java
@@ -1,0 +1,57 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FontSizeTest {
+
+    @Test
+    void acceptsAValueInsideTheAllowedRange() {
+        FontSizeOutcome outcome = FontSize.of(FontSize.MINIMUM_POINTS);
+
+        assertThat(outcome).isInstanceOf(FontSizeOutcome.Accepted.class);
+        assertThat(((FontSizeOutcome.Accepted) outcome).value().points()).isEqualTo(FontSize.MINIMUM_POINTS);
+    }
+
+    @Test
+    void acceptsTheUpperBound() {
+        FontSizeOutcome outcome = FontSize.of(FontSize.MAXIMUM_POINTS);
+
+        assertThat(outcome).isInstanceOf(FontSizeOutcome.Accepted.class);
+    }
+
+    @Test
+    void rejectsAValueBelowTheMinimum() {
+        FontSizeOutcome outcome = FontSize.of(FontSize.MINIMUM_POINTS - 1);
+
+        assertThat(outcome).isEqualTo(new FontSizeOutcome.Rejected(FontSizeRejection.BELOW_MINIMUM));
+    }
+
+    @Test
+    void rejectsAValueAboveTheMaximum() {
+        FontSizeOutcome outcome = FontSize.of(FontSize.MAXIMUM_POINTS + 1);
+
+        assertThat(outcome).isEqualTo(new FontSizeOutcome.Rejected(FontSizeRejection.ABOVE_MAXIMUM));
+    }
+
+    @Test
+    void theDefaultIsInsideItsOwnRange() {
+        // FontSize.DEFAULT は非公開コンストラクタで直接組み立てられている。
+        // 範囲内であることを保証しているのはこのテストである（JAV-007 の補完）。
+        assertThat(FontSize.of(FontSize.DEFAULT.points())).isInstanceOf(FontSizeOutcome.Accepted.class);
+        assertThat(FontSize.DEFAULT.points()).isBetween(FontSize.MINIMUM_POINTS, FontSize.MAXIMUM_POINTS);
+    }
+
+    @Test
+    void comparesByValue() {
+        FontSizeOutcome first = FontSize.of(FontSize.MINIMUM_POINTS);
+        FontSizeOutcome second = FontSize.of(FontSize.MINIMUM_POINTS);
+
+        assertThat(first).isEqualTo(second);
+        assertThat(first.hashCode()).isEqualTo(second.hashCode());
+        assertThat(first).isNotEqualTo(FontSize.of(FontSize.MAXIMUM_POINTS));
+        assertThat(FontSize.DEFAULT).isNotEqualTo(FontSize.MINIMUM_POINTS);
+        assertThat(FontSize.DEFAULT.toString()).contains(String.valueOf(FontSize.DEFAULT.points()));
+    }
+}

--- a/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/SettingsSchemaVersionTest.java
+++ b/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/SettingsSchemaVersionTest.java
@@ -1,0 +1,26 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.Test;
+
+class SettingsSchemaVersionTest {
+
+    @Test
+    void theCurrentVersionIsSupported() {
+        assertThat(SettingsSchemaVersion.CURRENT.isSupported()).isTrue();
+    }
+
+    @Test
+    void anUnknownFutureVersionIsNotSupported() {
+        SettingsSchemaVersion future = new SettingsSchemaVersion(SettingsSchemaVersion.CURRENT.value() + 1);
+
+        assertThat(future.isSupported()).isFalse();
+    }
+
+    @Test
+    void rejectsAVersionBelowOne() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new SettingsSchemaVersion(0));
+    }
+}

--- a/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/UserSettingsTest.java
+++ b/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/UserSettingsTest.java
@@ -1,0 +1,28 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UserSettingsTest {
+
+    @Test
+    void defaultsMatchTheSpecification() {
+        UserSettings settings = UserSettings.defaults();
+
+        assertThat(settings.clockFormat()).isEqualTo(ClockFormat.HOUR_24);
+        assertThat(settings.secondsVisibility()).isEqualTo(SecondsVisibility.SHOWN);
+        assertThat(settings.dateVisibility()).isEqualTo(DateVisibility.SHOWN);
+        assertThat(settings.windowTopmost()).isEqualTo(WindowTopmost.DISABLED);
+        assertThat(settings.fontSize()).isEqualTo(FontSize.DEFAULT);
+    }
+
+    // 「成分が null の UserSettings を作れない」ことは NullAway が
+    // コンパイル時に落とすため、テストとして書くことができない（JAV-004）。
+    // 実行時の requireNonNull は、注釈の外から呼ばれた場合の防御として残している。
+
+    @Test
+    void defaultsAreStable() {
+        assertThat(UserSettings.defaults()).isEqualTo(UserSettings.defaults());
+    }
+}

--- a/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/ClockPanel.java
+++ b/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/ClockPanel.java
@@ -1,0 +1,64 @@
+package io.github.hideyukimori.neneclock.ui.swing;
+
+import io.github.hideyukimori.neneclock.application.ClockFace;
+import io.github.hideyukimori.neneclock.application.DateLine;
+import io.github.hideyukimori.neneclock.domain.UserSettings;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.util.Objects;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
+/**
+ * 時計タブ。{@link ClockFace} をそのまま描く。
+ *
+ * <p>JPanel を継承せず内包する（構築中に自分のメソッドが呼ばれる形を作らないため）。
+ */
+public final class ClockPanel {
+
+    private static final int DATE_FONT_DIVISOR = 4;
+    private static final int MINIMUM_DATE_POINTS = 12;
+
+    private final JPanel panel = new JPanel(new GridBagLayout());
+    private final JLabel time = new JLabel("", SwingConstants.CENTER);
+    private final JLabel date = new JLabel("", SwingConstants.CENTER);
+
+    /** 部品を組み立てる。表示内容は {@code render*} が決める。 */
+    public ClockPanel() {
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.gridx = 0;
+        constraints.gridy = 0;
+        panel.add(time, constraints);
+        constraints.gridy = 1;
+        panel.add(date, constraints);
+    }
+
+    /** 画面に載せるための Swing 部品。 */
+    public JComponent component() {
+        return panel;
+    }
+
+    /** 表示文字列を反映する。 */
+    public void renderFace(ClockFace face) {
+        Objects.requireNonNull(face, "face");
+        time.setText(face.time());
+        switch (face.date()) {
+            case DateLine.Shown shown -> {
+                date.setText(shown.text());
+                date.setVisible(true);
+            }
+            case DateLine.Hidden hidden -> date.setVisible(false);
+        }
+    }
+
+    /** 設定を反映する。 */
+    public void renderSettings(UserSettings settings) {
+        Objects.requireNonNull(settings, "settings");
+        int points = settings.fontSize().points();
+        time.setFont(new Font(Font.MONOSPACED, Font.PLAIN, points));
+        date.setFont(new Font(Font.MONOSPACED, Font.PLAIN, Math.max(MINIMUM_DATE_POINTS, points / DATE_FONT_DIVISOR)));
+    }
+}

--- a/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/ClockTicker.java
+++ b/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/ClockTicker.java
@@ -1,0 +1,32 @@
+package io.github.hideyukimori.neneclock.ui.swing;
+
+import java.util.Objects;
+import javax.swing.Timer;
+
+/**
+ * 再描画のきっかけを作るだけの部品（SWG-005）。
+ *
+ * <p>刻みは時刻の正本ではない。表示する値は必ず
+ * {@link io.github.hideyukimori.neneclock.application.ClockFaceQuery} から取り直す。
+ */
+public final class ClockTicker {
+
+    private static final int TICK_MILLIS = 200;
+
+    private final Timer timer;
+
+    public ClockTicker(Runnable onTick) {
+        Objects.requireNonNull(onTick, "onTick");
+        this.timer = new Timer(TICK_MILLIS, event -> onTick.run());
+    }
+
+    /** 刻みを開始する。EDT から呼ぶこと（SWG-001）。 */
+    public void start() {
+        timer.start();
+    }
+
+    /** 刻みを止める。 */
+    public void stop() {
+        timer.stop();
+    }
+}

--- a/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/MainFrame.java
+++ b/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/MainFrame.java
@@ -1,0 +1,52 @@
+package io.github.hideyukimori.neneclock.ui.swing;
+
+import io.github.hideyukimori.neneclock.domain.UserSettings;
+import java.awt.Dimension;
+import java.util.Objects;
+import javax.swing.JFrame;
+import javax.swing.JTabbedPane;
+import javax.swing.WindowConstants;
+
+/**
+ * ウィンドウの合成と生存期間だけを持つ（ARC-011）。
+ *
+ * <p>時計・ストップウォッチ・タイマーの計算をここに置かない。
+ */
+public final class MainFrame {
+
+    private static final int INITIAL_WIDTH = 480;
+    private static final int INITIAL_HEIGHT = 240;
+    private static final int MINIMUM_WIDTH = 320;
+    private static final int MINIMUM_HEIGHT = 160;
+
+    private final JFrame frame = new JFrame("NeNe Clock");
+    private final ClockPanel clockPanel;
+
+    public MainFrame(ClockPanel clockPanel) {
+        this.clockPanel = Objects.requireNonNull(clockPanel, "clockPanel");
+        JTabbedPane tabs = new JTabbedPane();
+        tabs.addTab("Clock", clockPanel.component());
+        frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        frame.setContentPane(tabs);
+        frame.setSize(new Dimension(INITIAL_WIDTH, INITIAL_HEIGHT));
+        frame.setMinimumSize(new Dimension(MINIMUM_WIDTH, MINIMUM_HEIGHT));
+        frame.setLocationRelativeTo(null);
+    }
+
+    /** 設定を窓と各タブへ反映する。UI 状態の反映経路はここ 1 本（CNF-004）。 */
+    public void renderSettings(UserSettings settings) {
+        Objects.requireNonNull(settings, "settings");
+        boolean topmost =
+                switch (settings.windowTopmost()) {
+                    case ENABLED -> true;
+                    case DISABLED -> false;
+                };
+        frame.setAlwaysOnTop(topmost);
+        clockPanel.renderSettings(settings);
+    }
+
+    /** 窓を表示する。EDT から呼ぶこと（SWG-001）。 */
+    public void display() {
+        frame.setVisible(true);
+    }
+}

--- a/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/package-info.java
+++ b/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Swing 描画。状態を描き、意図を発行するだけ（ARC-011 / SWG-002）。
+ *
+ * <p>整形・検証・時刻の入手はここに置かない。UI 状態の反映は {@code render*} メソッドからのみ
+ * 行う（CNF-004）。
+ */
+@NullMarked
+package io.github.hideyukimori.neneclock.ui.swing;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Issue: #4
目的: M0 の機能（時計表示と設定の永続化）を、#2 で決めた規約が実際のコードで成立する形で実装する。
使った正典経路: 現在時刻は `WallClockPort`、表示文字列は `ClockFaceQuery`、永続化は `SettingsStorePort` の各 1 本。UI は決まった値を描くだけ。
規則 ID: ARC-001 / ARC-003 / ARC-007 / ARC-009 / ARC-010 / ARC-011 / JAV-002 / JAV-003 / JAV-005 / JAV-007 / SWG-002 / SWG-003
振る舞い・スキーマの変更: 設定の保存形式 v1 を新設（`schemaVersion` = 1）。読めない版は既定値へ黙って落とさず `UNSUPPORTED_SCHEMA` を返す。

検証（実行したコマンドと結果）:
- `./gradlew check` — このコミットのクリーンな作業木で成功（71 タスク）
- `:core:domain` / `:core:application` の分岐カバレッジは **100%**（下限は 90%）

**設計上の判断 2 件**

1. `ClockFaceQuery` に `showsDate(UserSettings)` を一度書いたが、`DateLine` と同じ判断を
   2 か所で持つことになるため削除した（ARC-001）。
2. `FontSize.DEFAULT` を `of()` 経由で組み立てると、到達し得ない「拒否側」の分岐が残り、
   それがカバレッジのゲートに「テストできない行」として現れた。到達しない防御コードを置くより
   不変条件をテストで示すほうが規律に合うと判断し、非公開コンストラクタで直接組み立てて
   範囲内であることを `FontSizeTest` が保証する形にした。

また、「成分が null の `UserSettings` を作れない」ことをテストに書こうとしたが、
NullAway がコンパイル時に落とすため**テストとして書けなかった**。該当箇所にその旨を残している。

Waivers: none
残るリスク: `PreferencesSettingsAdapterTest` は実際の `Preferences.userRoot()` 配下の専用ノードを使う。`$HOME` が書けない環境では失敗しうる（CI の ubuntu では問題なし）。

Closes #4
