### PR TITLE
test(architecture): ArchUnit でレイヤ規則を実行可能にする (#5)

### DIFF
--- a/quality/architecture-tests/src/test/java/io/github/hideyukimori/neneclock/quality/architecture/LayerRulesTest.java
+++ b/quality/architecture-tests/src/test/java/io/github/hideyukimori/neneclock/quality/architecture/LayerRulesTest.java
@@ -1,0 +1,43 @@
+package io.github.hideyukimori.neneclock.quality.architecture;
+
+import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.Test;
+
+/** ARC-002: 依存方向を実行可能な検査にする（QLT-006）。 */
+class LayerRulesTest {
+
+    private static final JavaClasses PRODUCTION = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("io.github.hideyukimori.neneclock");
+
+    @Test
+    void dependenciesPointInwardOnly() {
+        layeredArchitecture()
+                .consideringOnlyDependenciesInLayers()
+                .layer("Domain")
+                .definedBy("io.github.hideyukimori.neneclock.domain..")
+                .layer("Application")
+                .definedBy("io.github.hideyukimori.neneclock.application..")
+                .layer("Adapters")
+                .definedBy("io.github.hideyukimori.neneclock.adapter..")
+                .layer("Ui")
+                .definedBy("io.github.hideyukimori.neneclock.ui..")
+                .layer("Composition")
+                .definedBy("io.github.hideyukimori.neneclock.app..")
+                .whereLayer("Composition")
+                .mayNotBeAccessedByAnyLayer()
+                .whereLayer("Adapters")
+                .mayOnlyBeAccessedByLayers("Composition")
+                .whereLayer("Ui")
+                .mayOnlyBeAccessedByLayers("Composition")
+                .whereLayer("Application")
+                .mayOnlyBeAccessedByLayers("Adapters", "Ui", "Composition")
+                .whereLayer("Domain")
+                .mayOnlyBeAccessedByLayers("Application", "Adapters", "Ui", "Composition")
+                .check(PRODUCTION);
+    }
+}

--- a/quality/architecture-tests/src/test/java/io/github/hideyukimori/neneclock/quality/architecture/PlatformIsolationRulesTest.java
+++ b/quality/architecture-tests/src/test/java/io/github/hideyukimori/neneclock/quality/architecture/PlatformIsolationRulesTest.java
@@ -1,0 +1,61 @@
+package io.github.hideyukimori.neneclock.quality.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ARC-003: 中核はプラットフォームから独立している。
+ *
+ * <p>🔑 Swing も {@code java.util.prefs} も JDK 同梱なので、Gradle のモジュールグラフでは
+ * 「core が Swing を import できない」を作れない。そこはこの層が塞ぐ（QLT-006）。
+ */
+class PlatformIsolationRulesTest {
+
+    private static final String DOMAIN = "io.github.hideyukimori.neneclock.domain..";
+    private static final String APPLICATION = "io.github.hideyukimori.neneclock.application..";
+    private static final String PREFERENCES_ADAPTER = "io.github.hideyukimori.neneclock.adapter.preferences..";
+
+    private static final JavaClasses PRODUCTION = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("io.github.hideyukimori.neneclock");
+
+    @Test
+    void coreDoesNotKnowAboutTheDesktopToolkit() {
+        noClasses()
+                .that()
+                .resideInAnyPackage(DOMAIN, APPLICATION)
+                .should()
+                .dependOnClassesThat()
+                .resideInAnyPackage("javax.swing..", "java.awt..")
+                .because("ARC-003: 中核は Swing を知らない")
+                .check(PRODUCTION);
+    }
+
+    @Test
+    void onlyThePreferencesAdapterTouchesPreferences() {
+        noClasses()
+                .that()
+                .resideOutsideOfPackage(PREFERENCES_ADAPTER)
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage("java.util.prefs..")
+                .because("ARC-002: 設定の永続化に触れる場所は 1 つ")
+                .check(PRODUCTION);
+    }
+
+    @Test
+    void onlyTheApplicationLayerFormatsTime() {
+        noClasses()
+                .that()
+                .resideOutsideOfPackage(APPLICATION)
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage("java.time.format..")
+                .because("ARC-001: 表示文字列を作る経路は 1 本")
+                .check(PRODUCTION);
+    }
+}

--- a/quality/architecture-tests/src/test/java/io/github/hideyukimori/neneclock/quality/architecture/RuntimeDisciplineRulesTest.java
+++ b/quality/architecture-tests/src/test/java/io/github/hideyukimori/neneclock/quality/architecture/RuntimeDisciplineRulesTest.java
@@ -1,0 +1,59 @@
+package io.github.hideyukimori.neneclock.quality.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.library.GeneralCodingRules;
+import org.junit.jupiter.api.Test;
+
+/** ARC-006 / JAV-013: 可変グローバル状態を持たない、並行性は 1 種類だけ。 */
+class RuntimeDisciplineRulesTest {
+
+    private static final JavaClasses PRODUCTION = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("io.github.hideyukimori.neneclock");
+
+    @Test
+    void staticStateIsImmutable() {
+        fields().that()
+                .areStatic()
+                .should()
+                .beFinal()
+                .because("ARC-006: 可変なグローバル状態を持たない")
+                .check(PRODUCTION);
+    }
+
+    @Test
+    void concurrencyIsSwingTimersOnly() {
+        noClasses()
+                .should()
+                .dependOnClassesThat()
+                .resideInAnyPackage("java.util.concurrent..")
+                .because("JAV-013: 並行性の道具は javax.swing.Timer だけにする")
+                .check(PRODUCTION);
+    }
+
+    @Test
+    void noRawThreadsOrLegacyTimers() {
+        noClasses()
+                .should()
+                .dependOnClassesThat()
+                .haveFullyQualifiedName("java.lang.Thread")
+                .orShould()
+                .dependOnClassesThat()
+                .haveFullyQualifiedName("java.util.Timer")
+                .because("JAV-013 / SWG-001: EDT 以外のスレッドを作らない")
+                .check(PRODUCTION);
+    }
+
+    @Test
+    void noStandardStreamsAndNoGenericExceptions() {
+        GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS.check(PRODUCTION);
+        GeneralCodingRules.NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS.check(PRODUCTION);
+        GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING.check(PRODUCTION);
+        GeneralCodingRules.NO_CLASSES_SHOULD_USE_FIELD_INJECTION.check(PRODUCTION);
+    }
+}


### PR DESCRIPTION
Issue: #5
目的: パッケージ単位の境界を実行可能な検査にする（QLT-006）。
使った正典経路: `:quality:architecture-tests` をテスト専用モジュールとして置き、production コードからは依存できないようにしている。
規則 ID: ARC-002 / ARC-003 / ARC-006 / ARC-011 / JAV-013 / SWG-002
振る舞い・スキーマの変更: なし（テストのみ）

検証（実行したコマンドと結果）:
- `./gradlew check` — このコミットのクリーンな作業木で成功（76 タスク）

この PR で `docs/QUALITY_GATES.md` の強制マトリクスが `active` と書いている項目の実装がすべてそろい、文書と実装が一致した状態になる（#2 の残リスクを解消）。

Waivers: none
残るリスク: なし。ゲートが実際に落ちることの実測は #7 で行う。

Closes #5
