### PR TITLE
ci: GitHub Actions と main 保護を構築する (#6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+# QLT-001 / QLT-005: CI は品質判断を持たない。ローカルと同じ `./gradlew check` を呼ぶだけ。
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: quality
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+          validate-wrappers: true
+
+      - name: Run the canonical gate
+        run: ./gradlew check --stacktrace
+
+      - name: Fail if the working tree drifted
+        run: git diff --exit-code


### PR DESCRIPTION
Issue: #6
目的: `main` に壊れたものが入らないようにし、CI が第 2 の完了定義を持たないようにする。
使った正典経路: CI は `./gradlew check` を実行するだけ。品質のロジックは Gradle 側にしか無い。
規則 ID: QLT-001 / QLT-005
振る舞い・スキーマの変更: なし

検証（実行したコマンドと結果）: この PR 自体が `quality` ジョブの最初の実行になる。緑を確認したうえで merge し、その後 `main` の ruleset を設定して API で読み戻す。

Waivers: none
残るリスク: ruleset は merge 後に設定するため、この PR だけは保護が効いていない状態で入る。

Closes #6
