### PR TITLE
docs(todo): 現在のタスク一覧に Issue 番号を紐づける (#20)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,13 +12,12 @@
 - [x] 時計表示（FR-001..FR-006）と設定永続化（FR-040..FR-042）
 - [x] CI（`quality` ジョブが `./gradlew check` を実行）
 - [x] GitHub へ push し、`main` の ruleset を設定して [quality/gate-proofs.md](../quality/gate-proofs.md) に記録する
-- [ ] WSLg での表示確認を記録する（QLT-012）
+- [ ] WSLg での表示確認を記録する（QLT-012）— #14
 
 ## M1（未着手）
 
-- [ ] FR-010 ストップウォッチ（単調時刻・状態機械）
-- [ ] FR-020 カウントダウンタイマー（目標時刻からの計算）
-- [ ] FR-050 残り 3 タブ（設定 UI を含む）
-- [ ] SWG-004 の機械強制（`setLayout(null)` / `setBounds` の検出）を `planned` → `active`
-- [ ] SWG-005 の機械強制（減算カウンタの検出）を `planned` → `active`
-- [ ] QLT-011 の SHA-256 dependency verification を `planned` → `active`
+- [ ] FR-010 ストップウォッチ（単調時刻・状態機械）— #15
+- [ ] FR-020 カウントダウンタイマー（目標時刻からの計算）— #16
+- [ ] FR-050 残り 3 タブ（設定 UI を含む）— #17
+- [ ] SWG-004 / SWG-005 の機械強制を `planned` → `active` — #18
+- [ ] QLT-011 の SHA-256 dependency verification を `planned` → `active` — #19


### PR DESCRIPTION
Issue: #20
目的: `docs/todo/current.md` の各項目から正本（GitHub Issue）へ辿れるようにする。
使った正典経路: タスク状態の正本は Issue のまま。ドキュメントは写しとして番号だけを持つ。
規則 ID: なし（ドキュメントの整合）
振る舞い・スキーマの変更: なし
検証（実行したコマンドと結果）: `./gradlew check`（CI の `quality` ジョブ）
Waivers: none
残るリスク: なし

Closes #20