### PR TITLE
fix(build): determinism.txt を実際に読み込ませ、証明を実測で取り直す (#26)

### DIFF
--- a/adapters/system-time/build.gradle.kts
+++ b/adapters/system-time/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
 // 🔑 このモジュールだけ determinism.txt を外す。ARC-007 の「唯一の窓口」がここであることを、
 //    ビルドファイルの差分として一目で見える形に残す。他のモジュールで同じことを書いたら
 //    validateConformance ではなく PR レビューで落とす（QLT-010）。
+//
+//    ⚠️ この上書きは 2026-09-03 まで no-op だった。convention 側が determinism.txt を
+//    読み込んでおらず、外す対象が存在しなかったため（Issue #26）。
 tasks.withType<CheckForbiddenApis>().configureEach {
     signaturesFiles = files(rootProject.file("config/forbiddenapis/base.txt"))
 }

--- a/build-logic/src/main/java/io/github/hideyukimori/neneclock/gradle/conformance/ConfigurationWiringRules.java
+++ b/build-logic/src/main/java/io/github/hideyukimori/neneclock/gradle/conformance/ConfigurationWiringRules.java
@@ -1,0 +1,53 @@
+package io.github.hideyukimori.neneclock.gradle.conformance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 設定ファイルの結線（CNF-011）。
+ *
+ * <p>`config/` に置いた検査設定が、どのビルドスクリプトからも読み込まれていない状態を拒否する。
+ * 「署名ファイルは存在するのに誰も読んでいない」ために、規則が守られていると誤読した実害があった
+ * （Issue #26。詳細は quality/gate-proofs.md 第 3 節）。
+ */
+public final class ConfigurationWiringRules {
+
+    private static final String CONFIG_PREFIX = "config/";
+
+    private ConfigurationWiringRules() {}
+
+    /**
+     * @param configurationPaths `config/` 配下のファイルパス
+     * @param wiringSources ビルドスクリプトと build-logic のソース（読み込み側になりうるもの）
+     */
+    public static List<Violation> check(List<String> configurationPaths, List<SourceFile> wiringSources) {
+        List<Violation> violations = new ArrayList<>();
+        for (String path : configurationPaths) {
+            if (!path.startsWith(CONFIG_PREFIX)) {
+                continue;
+            }
+            String fileName = fileNameOf(path);
+            if (!isReferenced(fileName, wiringSources)) {
+                violations.add(Violation.atFile(
+                        "CNF-011", path, "この設定ファイルを読み込むビルドスクリプトが無い。置いても効かない"));
+            }
+        }
+        return List.copyOf(violations);
+    }
+
+    private static boolean isReferenced(String fileName, List<SourceFile> wiringSources) {
+        for (SourceFile source : wiringSources) {
+            for (String line : source.lines()) {
+                if (line.contains(fileName)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static String fileNameOf(String path) {
+        int slash = path.lastIndexOf('/');
+        return slash < 0 ? path : path.substring(slash + 1);
+    }
+}

--- a/build-logic/src/main/java/io/github/hideyukimori/neneclock/gradle/conformance/ConformanceCheck.java
+++ b/build-logic/src/main/java/io/github/hideyukimori/neneclock/gradle/conformance/ConformanceCheck.java
@@ -53,6 +53,10 @@ public final class ConformanceCheck {
         violations.addAll(WaiverLedger.check(waiverFiles, waiverIndex, referencedWaivers, today));
 
         violations.addAll(BaselineRules.check(allPaths, configurationFiles));
+
+        List<SourceFile> wiringSources =
+                read(allPaths, path -> path.endsWith(".gradle.kts") || path.startsWith("build-logic/src/main/java/"));
+        violations.addAll(ConfigurationWiringRules.check(allPaths, wiringSources));
         violations.addAll(ModuleGraphRules.check(moduleGraph, approvedModules, approvedEdges));
         return List.copyOf(violations);
     }

--- a/build-logic/src/main/java/io/github/hideyukimori/neneclock/gradle/conformance/JavaSourceRules.java
+++ b/build-logic/src/main/java/io/github/hideyukimori/neneclock/gradle/conformance/JavaSourceRules.java
@@ -60,7 +60,7 @@ public final class JavaSourceRules {
         int depth = 0;
         int topLevelTypes = 0;
         String primaryType = null;
-        String previousCode = "";
+        String previousLine = "";
         Deque<Method> methods = new ArrayDeque<>();
 
         for (int index = 0; index < file.lines().size(); index++) {
@@ -72,7 +72,7 @@ public final class JavaSourceRules {
 
             checkPackage(file, violations, lineNumber, code);
             checkTaskMarker(file, violations, lineNumber, text.comment());
-            checkSuppression(file, violations, referencedWaivers, lineNumber, code, previousCode);
+            checkSuppression(file, violations, referencedWaivers, new Suppression(lineNumber, code, raw, previousLine));
 
             if (code.contains("default:") || code.contains("default ->")) {
                 violations.add(new Violation(
@@ -107,8 +107,10 @@ public final class JavaSourceRules {
             if (uiSource) {
                 checkRenderOnlyCall(file, violations, lineNumber, code, methods.peek());
             }
-            if (!code.isBlank()) {
-                previousCode = raw;
+            // 🔴 直前「行」であってコード行ではない。waiver は `// Waiver: WVR-NNNN` という
+            //    コメント行なので、コード行だけを覚えると永久に見つからない（Issue #26）。
+            if (!raw.isBlank()) {
+                previousLine = raw;
             }
         }
 
@@ -154,31 +156,34 @@ public final class JavaSourceRules {
     }
 
     private static void checkSuppression(
-            SourceFile file,
-            List<Violation> violations,
-            List<String> referencedWaivers,
-            int lineNumber,
-            String code,
-            String previousLine) {
-        if (!SUPPRESSION.matcher(code).find()) {
+            SourceFile file, List<Violation> violations, List<String> referencedWaivers, Suppression suppression) {
+        if (!SUPPRESSION.matcher(suppression.code()).find()) {
             return;
         }
-        if (code.contains("\"all\"")) {
+        // 🔴 抑制の中身は raw 行で見る。CodeText は文字列リテラルの中身を空白に潰すので、
+        //    code 側を見ると @SuppressWarnings("all") の "all" が消えて検出できない（Issue #26）。
+        if (suppression.raw().contains("\"all\"")) {
             violations.add(new Violation(
-                    "CNF-002", file.path(), lineNumber, "@SuppressWarnings(\"all\") は waiver でも許可されない"));
+                    "CNF-002",
+                    file.path(),
+                    suppression.lineNumber(),
+                    "@SuppressWarnings(\"all\") は waiver でも許可されない"));
             return;
         }
-        Matcher waiver = WAIVER_REFERENCE.matcher(previousLine);
+        Matcher waiver = WAIVER_REFERENCE.matcher(suppression.previousLine());
         if (!waiver.find()) {
             violations.add(new Violation(
                     "CNF-002",
                     file.path(),
-                    lineNumber,
+                    suppression.lineNumber(),
                     "@SuppressWarnings の直前行に // Waiver: WVR-NNNN が必要"));
             return;
         }
         referencedWaivers.add(waiver.group(1));
     }
+
+    /** 抑制 1 か所を見るために要る文脈。 */
+    private record Suppression(int lineNumber, String code, String raw, String previousLine) {}
 
     private static void checkRenderOnlyCall(
             SourceFile file, List<Violation> violations, int lineNumber, String code, Method enclosing) {

--- a/build-logic/src/main/kotlin/neneclock.java-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/neneclock.java-conventions.gradle.kts
@@ -71,18 +71,27 @@ tasks.named<Checkstyle>("checkstyleTest") {
 }
 
 // 機械強制の分担: forbidden-apis は「メソッド単位」、ArchUnit は「パッケージ／レイヤ単位」。
+// 🔴 signaturesFiles をここで組み立てて main / test の両方へ渡す。片方だけに渡すと、
+//    署名ファイルが存在するのに誰も読まない状態が静かに成立する（実測あり・Issue #26）。
+val projectSignatures =
+    files(
+        rootProject.file("config/forbiddenapis/base.txt"),
+        rootProject.file("config/forbiddenapis/determinism.txt"),
+    )
+
 forbiddenApis {
     bundledSignatures =
         setOf("jdk-unsafe", "jdk-deprecated", "jdk-non-portable", "jdk-internal", "jdk-reflection", "jdk-system-out")
-    signaturesFiles = files(rootProject.file("config/forbiddenapis/base.txt"))
+    signaturesFiles = projectSignatures
     failOnUnsupportedJava = false
     ignoreSignaturesOfMissingClasses = true
 }
 
 tasks.named<de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis>("forbiddenApisTest") {
-    // テストは固定時刻の生成に java.time を素で使う。決定性は「実時刻を読まないこと」で担保する。
+    // テストは固定時刻の生成に java.time を素で使ってよい（Clock.fixed / LocalDateTime.of）。
+    // ただし実時刻を読むことは禁じる。テストが実時刻を読むのも決定性の破壊である。
     bundledSignatures = setOf("jdk-deprecated", "jdk-non-portable", "jdk-internal", "jdk-reflection")
-    signaturesFiles = files(rootProject.file("config/forbiddenapis/base.txt"))
+    signaturesFiles = projectSignatures
 }
 
 tasks.withType<Test>().configureEach {

--- a/build-logic/src/test/java/io/github/hideyukimori/neneclock/gradle/conformance/ConfigurationWiringRulesTest.java
+++ b/build-logic/src/test/java/io/github/hideyukimori/neneclock/gradle/conformance/ConfigurationWiringRulesTest.java
@@ -1,0 +1,46 @@
+package io.github.hideyukimori.neneclock.gradle.conformance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** CNF-011 の negative proof（QLT-007）。 */
+class ConfigurationWiringRulesTest {
+
+    private static final SourceFile CONVENTIONS = SourceFile.of(
+            "build-logic/src/main/kotlin/neneclock.java-conventions.gradle.kts",
+            """
+            forbiddenApis {
+                signaturesFiles = files(rootProject.file("config/forbiddenapis/base.txt"))
+            }
+            """);
+
+    @Test
+    void acceptsAConfigurationFileThatSomeBuildScriptReads() {
+        List<Violation> violations =
+                ConfigurationWiringRules.check(List.of("config/forbiddenapis/base.txt"), List.of(CONVENTIONS));
+
+        assertEquals(List.of(), violations);
+    }
+
+    @Test
+    void rejectsAConfigurationFileThatNothingReads() {
+        List<Violation> violations = ConfigurationWiringRules.check(
+                List.of("config/forbiddenapis/base.txt", "config/forbiddenapis/determinism.txt"),
+                List.of(CONVENTIONS));
+
+        assertEquals(1, violations.size());
+        assertEquals("CNF-011", violations.get(0).ruleId());
+        assertTrue(violations.get(0).path().endsWith("determinism.txt"));
+    }
+
+    @Test
+    void ignoresPathsOutsideTheConfigurationDirectory() {
+        List<Violation> violations =
+                ConfigurationWiringRules.check(List.of("docs/QUALITY_GATES.md"), List.of(CONVENTIONS));
+
+        assertEquals(List.of(), violations);
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,3 +4,10 @@ plugins {
 
 // ルートは合成と検査のみを持つ。production コードを置かない。
 description = "NeNe Clock — Java 21 / Swing デスクトップ時計"
+
+// QLT-001 / QLT-007: 検査そのもののテストも唯一のゲートに入れる。
+// build-logic は included build なので、明示的に依存させないと `check` から呼ばれない。
+// 呼ばれていなかった間、規約検査の単体テストは 1 件落ちたまま気づかれなかった（Issue #26）。
+tasks.named("check") {
+    dependsOn(gradle.includedBuild("build-logic").task(":test"))
+}

--- a/docs/QUALITY_GATES.md
+++ b/docs/QUALITY_GATES.md
@@ -18,6 +18,7 @@
 CI のワークフローに品質判断のシェルロジックを書かない。第 2 の完了定義を文書化しない。
 
 - 機械強制: **active**（`.github/workflows/ci.yml` は `./gradlew check` を呼ぶだけ）
+- 機械強制: **active**（`config/` の設定が実際に読み込まれていることは CNF-011 が見る）
 - 機械強制: **planned**（CI がゲートを再構成していないことの機械検査）
 
 ### QLT-002 — 警告は失敗する
@@ -110,6 +111,8 @@ lock ファイルのドリフトはビルドを落とす。
 
 `validateConformance` が実行する自作検査。実体は `build-logic/src/main/java/.../conformance/`
 （依存ゼロの Java）で、各規則には正例・反例の単体テストがある（QLT-007）。
+そのテストはルートの `check` から依存させている。**included build のタスクは自動では
+呼ばれない**ため、結線しないと落ちたまま気づかれない（Issue #26 で実際に起きた）。
 
 ### CNF-001 — 禁止された総称名
 
@@ -159,6 +162,15 @@ waiver ファイルの命名・必須項目（Rule / Scope / Issue / Expires）�
 
 `config/architecture/module-graph.txt` に無いモジュール、許可されていない依存辺、
 モジュール間の循環を拒否する（ARC-002）。
+
+### CNF-011 — 宣言した検査設定が実際に読み込まれていること
+
+`config/` に置いた検査設定のうち、どのビルドスクリプトからも読み込まれていないものを拒否する。
+
+🔴 この規則は事故から生まれた。`config/forbiddenapis/determinism.txt` が
+**どのビルドにも読み込まれていない**まま「ARC-007 は active」と書かれていた時期がある
+（Issue #26。経緯は [quality/gate-proofs.md](quality/gate-proofs.md) 第 3 節）。
+設定ファイルは、置いただけでは何も守らない。
 
 ---
 
@@ -210,6 +222,7 @@ waiver ファイルの命名・必須項目（Rule / Scope / Issue / Expires）�
 | CNF-008 | active | `BaselineRules` |
 | CNF-009 | active | `WaiverLedger` |
 | CNF-010 | active | `ModuleGraphRules` |
+| CNF-011 | active | `ConfigurationWiringRules` |
 
 ---
 
@@ -223,7 +236,8 @@ waiver ファイルの命名・必須項目（Rule / Scope / Issue / Expires）�
 | API 禁止 | メソッド単位の禁止 | forbidden-apis（base / determinism / bundled 束） |
 | 静的解析 | 構造と複雑度 | Checkstyle |
 | アーキテクチャ | レイヤ・パッケージ境界 | ArchUnit（`:quality:architecture-tests`） |
-| 規約検査 | NeNe Clock 固有 | `validateConformance`（CNF-001..010） |
+| 規約検査 | NeNe Clock 固有 | `validateConformance`（CNF-001..011） |
+| 検査自身のテスト | 規約検査の正例・反例 | `:build-logic:test`（`check` から依存する） |
 | 単体テスト | 振る舞い | JUnit 5（headless） |
 | カバレッジ | 中核の検証密度 | JaCoCo（core 2 モジュールで分岐 90%） |
 | 依存 | 再現性 | Gradle dependency locking |

--- a/docs/quality/gate-proofs.md
+++ b/docs/quality/gate-proofs.md
@@ -14,9 +14,11 @@ CI: ubuntu-24.04 / Temurin 21 / 同梱 Wrapper
 
 ## 1. 実測結果
 
+最終実測 2026-09-03（Issue #26 の修正後に全件を取り直した）。
+
 | # | 規則 | 仕込んだ違反 | 実行したタスク | 結果 |
 | --- | --- | --- | --- | --- |
-| P1 | ARC-007 | `:core:application` で `LocalDateTime.now()` を呼ぶ | `:core:application:forbiddenApisMain` | **失敗** |
+| P1 | ARC-007 | `:core:application` で `System.nanoTime()` と `Instant.now()` を呼ぶ | `:core:application:forbiddenApisMain` | **失敗** |
 | P2 | ARC-003 | `:core:domain` から `javax.swing.JLabel` を参照する | `:quality:architecture-tests:test` | **失敗** |
 | P3 | CNF-003 | `switch` に `default ->` を書く | `validateConformance` | **失敗** |
 | P4 | CNF-010 | `:ui:swing` から `:adapters:preferences` へ依存を足す | `validateConformance` | **失敗** |
@@ -27,31 +29,41 @@ CI: ubuntu-24.04 / Temurin 21 / 同梱 Wrapper
 | P9 | CNF-001 | 入れ子クラスを `TimeHelper` と命名する | `validateConformance` | **失敗** |
 | P10 | CNF-004 | `render*` 以外のメソッドで `setEnabled(...)` を呼ぶ | `validateConformance` | **失敗** |
 | P11 | JAV-009 | 未使用の import を残す | `:core:domain:checkstyleMain` | **失敗** |
+| P12 | CNF-011 | どこからも読み込まれない設定ファイルを `config/` に置く | `validateConformance` | **失敗** |
 
-**復帰の確認**: 11 件すべてについて、仕込みを戻したあと `./gradlew check` が終了コード 0 で成功した。
+**復帰の確認**: 12 件すべてについて、仕込みを戻したあと `./gradlew check` が終了コード 0 で成功した。
+
+**除外側の確認（ARC-007）**: `:adapters:system-time` は `LocalDateTime.now(Clock)` /
+`Clock.system(ZoneId)` / `ZoneId.systemDefault()` を呼んでいる。いずれも `determinism.txt` に
+載っている署名だが、このモジュールだけ同ファイルを適用しないため `:adapters:system-time:check` は成功する。
+**禁止が効いていることと、唯一の窓口が通ることの両方を見ている。**
 
 ---
 
-## 2. 出力の抜粋
+## 2. 出力の抜粋（実行結果からの引用）
 
 ```text
-P1  Forbidden method invocation: java.time.LocalDateTime#now()
-      [現在時刻は WallClockPort / TickSource からのみ得る。ここで読むと決定性が壊れる（ARC-007）]
+P1  Forbidden method invocation: java.lang.System#nanoTime() [現在時刻は WallClockPort / TickSource からのみ得る。ここで読むと決定性が壊れる（ARC-007）]
+    Forbidden method invocation: java.time.Instant#now() [現在時刻は WallClockPort / TickSource からのみ得る。ここで読むと決定性が壊れる（ARC-007）]
+    Scanned 17 class file(s) for forbidden API invocations (in 0.02s), 2 error(s).
 
-P2  Architecture Violation — Rule 'no classes that reside in any package
-      ['...domain..', '...application..'] should depend on classes that reside in any package
-      ['javax.swing..', 'java.awt..'], because ARC-003: 中核は Swing を知らない'
+P2  java.lang.AssertionError: Architecture Violation [Priority: MEDIUM] - Rule 'no classes that
+    reside in any package ['io.github.hideyukimori.neneclock.domain..',
+    'io.github.hideyukimori.neneclock.application..'] should depend on classes that reside in any
+    package ['javax.swing..', 'java.awt..'], because ARC-003: 中核は Swing を知らない' was violated (1 times):
+    Method <io.github.hideyukimori.neneclock.domain.SettingsSchemaVersion.toolkit()> references
+    class object <javax.swing.JLabel> in (SettingsSchemaVersion.java:21)
 
-P3  CNF-003 core/application/.../ClockFaceQuery.java:43
+P3  CNF-003 core/application/src/main/java/io/github/hideyukimori/neneclock/application/ClockFaceQuery.java:43
       — switch に default を書かない。網羅性検査を無効化する
 
-P4  CNF-010 docs/PROJECT_LAYOUT.md
-      — 許可されていない依存: :ui:swing -> :adapters:preferences
+P4  CNF-010 docs/PROJECT_LAYOUT.md — 許可されていない依存: :ui:swing -> :adapters:preferences
 
-P5  SettingsSchemaVersion.java:20: warning: [rawtypes] found raw type: List
+P5  core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/SettingsSchemaVersion.java:20:
+      warning: [rawtypes] found raw type: List
     error: warnings found and -Werror specified
 
-P6  CNF-002 core/domain/.../SettingsSchemaVersion.java:20
+P6  CNF-002 core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/SettingsSchemaVersion.java:20
       — @SuppressWarnings の直前行に // Waiver: WVR-NNNN が必要
 
 P7  CNF-009 docs/waivers/WVR-0001-expired-proof.md:6
@@ -59,50 +71,76 @@ P7  CNF-009 docs/waivers/WVR-0001-expired-proof.md:6
 
 P8  The following files had format violations: ... Run './gradlew spotlessApply' to fix all violations.
 
-P9  CNF-001 core/domain/.../SettingsSchemaVersion.java:20
+P9  CNF-001 core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/SettingsSchemaVersion.java:20
       — 禁止された総称型名: TimeHelper（役割を名前で語る）
 
-P10 CNF-004 ui/swing/.../MainFrame.java:34
+P10 CNF-004 ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/MainFrame.java:34
       — setEnabled( を MainFrame で呼んでいる。UI 状態の反映は render* からのみ
 
-P11 [ERROR] core/domain/.../SettingsSchemaVersion.java:3:8:
+P11 [ant:checkstyle] [ERROR] core/domain/.../SettingsSchemaVersion.java:3:8:
       Unused import - java.util.List. [UnusedImports]
+
+P12 CNF-011 config/forbiddenapis/orphan.txt
+      — この設定ファイルを読み込むビルドスクリプトが無い。置いても効かない
 ```
 
 ---
 
 ## 3. 証明の途中で分かったこと
 
-🔑 **最初の P5 は「未使用 import を残す」で試したが、ビルドは通ってしまった。**
+### 3.1 QLT-002 の担当を取り違えていた
+
+最初の P5 は「未使用 import を残す」で試したが、ビルドは通ってしまった。
 `javac -Xlint:all` に未使用 import の検査は無い（`-Xlint` のカテゴリに存在しない）。
-つまり **QLT-002（警告は失敗する）は未使用 import を守っていない**。
 守っているのは Checkstyle の `UnusedImports` であり、それが P11 である。
 
-これは「ゲートがあると思っていた場所に無い」典型例であり、
-negative proof を取らなければ気づかないまま
-「コンパイラが見ている」と書き続けていた。**QLT-007 が要る理由そのものである。**
+### 3.2 🔴 ARC-007 のゲートは、実は半分しか繋がっていなかった（Issue #26）
 
----
+**最初にこの文書を書いた時点で、`config/forbiddenapis/determinism.txt` は
+どのビルドスクリプトからも読み込まれていなかった。** `neneclock.java-conventions` の
+`signaturesFiles` が `base.txt` だけを指していたためである。
 
-## 4. 規則単位のテスト（`validateConformance` の内部）
+それでも P1 が「落ちた」のは、bundled signature の `jdk-unsafe` が
+**既定タイムゾーンを使うメソッド**を禁じており、最初の証明に使った `LocalDateTime.now()` が
+たまたまそれに当たったからだった。実際には次が素通りしていた。
 
-上の end-to-end の証明とは別に、`build-logic` の単体テストが各 CNF 規則について
-正例（通る入力）と反例（落ちる入力）の両方を持つ。
-
-```bash
-./gradlew -p build-logic test
+```java
+long probe = System.nanoTime() + java.time.Instant.now().toEpochMilli();   // 修正前は通った
 ```
 
-| テストクラス | 対象 |
-| --- | --- |
-| `JavaSourceRulesTest` | CNF-001 / CNF-002 / CNF-003 / CNF-004 / CNF-006 / CNF-007 |
-| `DocumentationRulesTest` | CNF-005 |
-| `WaiverLedgerTest` | CNF-009 |
-| `BaselineRulesTest` | CNF-008 |
-| `ModuleGraphRulesTest` | CNF-010 |
+さらに `:adapters:system-time/build.gradle.kts` の「このモジュールだけ determinism.txt を外す」
+という上書きも、外す対象が最初から入っていないため **no-op** だった。
 
-`JavaSourceRulesTest` は「文字列リテラル中の `default ->` を誤検知しないこと」のような
-**偽陽性側**の反例も持つ。検査が正しく落ちることと、正しく落ちないことの両方を見る。
+🔴 **加えて、この文書の初版に載せた P1 の出力抜粋は、実際の出力ではなく期待した内容だった。**
+証明の記録として誤りであり、`docs/QUALITY_GATES.md` の ARC-007 の `active` も過大な主張だった。
+Issue #26 で署名を実際に読み込ませ、**全 11 件を実行結果からの引用で取り直した**のが第 2 節である。
+
+**教訓**: negative proof は「落ちること」だけでなく **「何によって落ちたか」**まで確かめないと、
+別の道具がたまたま拾っているだけの状態を「このゲートが効いている」と誤読する。
+出力は必ず実行結果から引用する。
+
+**再発防止**: CNF-011 を新設した。`config/` に置いた設定が、どのビルドスクリプトからも
+読み込まれていなければ `validateConformance` が落ちる。
+
+### 3.3 🔴 規約検査そのもののテストが、ゲートから呼ばれていなかった（Issue #26）
+
+`build-logic` は included build なので、**そのタスクはルートの `check` からは自動で呼ばれない**。
+「各 CNF 規則に正例・反例の単体テストがある」と書いていたが、`./gradlew check` も CI も
+そのテストを一度も実行していなかった。
+
+初めて `./gradlew -p build-logic test` を回したところ、**2 件が落ちた**。どちらも検査側の欠陥である。
+
+1. CNF-002 が waiver コメントを見つけられなかった。「直前行」を探すのに**コード行**だけを
+   覚えていたため、`// Waiver: WVR-NNNN` というコメント行は候補にならなかった。
+   つまり **waiver を正しく書いても通らない**状態だった
+2. `@SuppressWarnings("all")` を検出できていなかった。`CodeText` が文字列リテラルの中身を
+   空白へ潰すため、潰したあとの文字列から `"all"` を探していた
+
+🔑 1 の欠陥は、テストの側でも見えていなかった。waiver 付きの抑制が
+「waiver が無い」という**別の理由**で拒否されており、テストは規則 ID だけを見ていたので通っていた。
+**正しい理由で落ちているかまで見ないと、テストも証明にならない。**
+
+対策として `check` に `:build-logic:test` を依存させた。
 
 ---
 


### PR DESCRIPTION
Issue: #26
目的: 「あると書いてあるが実際には効いていないゲート」を無くし、証明の記録を実測に置き換える。
使った正典経路: 署名ファイルは convention 側で 1 か所に組み立てて main / test の両方へ渡す。モジュール個別の除外は、そのモジュールの `build.gradle.kts` に差分として見える形のまま。
規則 ID: ARC-007 / QLT-001 / QLT-002 / QLT-007 / CNF-002 / CNF-011（新設）
振る舞い・スキーマの変更: なし（ビルドと検査のみ）

## 何が壊れていたか

**1. `determinism.txt` がどのビルドにも読み込まれていなかった**

`neneclock.java-conventions` の `signaturesFiles` が `base.txt` だけを指していた。
ARC-007 が「落ちている」ように見えていたのは、bundled の `jdk-unsafe` が
**既定タイムゾーンを使うメソッド**を禁じており、最初の証明に使った `LocalDateTime.now()` が
たまたまそれに当たったから。実測で次が素通りしていた。

```java
long probe = System.nanoTime() + java.time.Instant.now().toEpochMilli();   // 修正前は通った
```

`:adapters:system-time` の「このモジュールだけ determinism.txt を外す」上書きも、
外す対象が入っていないため **no-op** だった。

**2. `build-logic` のテストが `check` から呼ばれていなかった**

included build のタスクは自動では呼ばれない。「各 CNF 規則に正例・反例のテストがある」と
書いていたが、`./gradlew check` も CI も一度も実行していなかった。初回実行で **2 件が落ちた**。

- CNF-002 が「直前行」を**コード行だけ**で探しており、`// Waiver: WVR-NNNN` を見つけられなかった。
  **waiver を正しく書いても通らない**状態だった
- `@SuppressWarnings("all")` を、文字列リテラルを潰したあとの文字列から探していて検出できていなかった

🔑 1 つ目の欠陥はテスト側でも見えていなかった。waiver 付きの抑制が「waiver が無い」という
**別の理由**で拒否されており、テストが規則 ID しか見ていなかったので通っていた。
正しい理由で落ちているかまで見ないと、テストも証明にならない。

**3. 証明の記録そのものが誤っていた**

`docs/quality/gate-proofs.md` の初版に載せた P1 の出力抜粋は、実際の出力ではなく期待した内容だった。

## 直したこと

- 署名ファイルを convention で組み立てて main / test 両方へ渡す
- `check` に `:build-logic:test` を依存させる
- CNF-002 の「直前行」を raw 行で探し、`"all"` の検出も raw 行で行う
- **CNF-011 を新設**: `config/` の設定がどのビルドスクリプトからも読み込まれていなければ落とす（再発防止）
- 全 12 件の証明を**実行結果からの引用**で取り直し、誤っていた事実を `gate-proofs.md` に残した

検証（実行したコマンドと結果）:
- 修正前: `:core:application` に `System.nanoTime()` / `Instant.now()` を仕込んで `forbiddenApisMain` → **通った**
- 修正後: 同じ仕込みで `Forbidden method invocation: java.lang.System#nanoTime()` / `java.time.Instant#now()` により **失敗**
- `:adapters:system-time:check` は成功（除外側が従来どおり動く）
- `./gradlew check` 成功（`:build-logic:test` を含む）
- negative proof 12 件がすべて意図した規則 ID で失敗し、復帰後に緑

Waivers: none
残るリスク: `jdk-unsafe` と `determinism.txt` は一部の署名が重なる。重複によるビルド失敗は出ていないが、将来 bundled 側の内容が変わると気づきにくい。

Closes #26