### PR TITLE
feat(settings): 書体・文字色を値として持ち、保存形式を v2 へ移行する (#23)

### DIFF
--- a/adapters/preferences/src/main/java/io/github/hideyukimori/neneclock/adapter/preferences/PreferencesSettingsAdapter.java
+++ b/adapters/preferences/src/main/java/io/github/hideyukimori/neneclock/adapter/preferences/PreferencesSettingsAdapter.java
@@ -7,6 +7,10 @@ import io.github.hideyukimori.neneclock.application.SettingsSaveOutcome;
 import io.github.hideyukimori.neneclock.application.SettingsStorePort;
 import io.github.hideyukimori.neneclock.domain.ClockFormat;
 import io.github.hideyukimori.neneclock.domain.DateVisibility;
+import io.github.hideyukimori.neneclock.domain.FontColor;
+import io.github.hideyukimori.neneclock.domain.FontColorOutcome;
+import io.github.hideyukimori.neneclock.domain.FontFamily;
+import io.github.hideyukimori.neneclock.domain.FontFamilyOutcome;
 import io.github.hideyukimori.neneclock.domain.FontSize;
 import io.github.hideyukimori.neneclock.domain.FontSizeOutcome;
 import io.github.hideyukimori.neneclock.domain.SecondsVisibility;
@@ -18,7 +22,12 @@ import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import org.jspecify.annotations.Nullable;
 
-/** {@link Preferences} に設定を保存する {@link SettingsStorePort} の実装。 */
+/**
+ * {@link Preferences} に設定を保存する {@link SettingsStorePort} の実装。
+ *
+ * <p>保存形式を知るのはこのクラスだけである。版の移行もここに閉じる（ADR 0003）。
+ * {@link #load()} は保存領域を書き換えない。v2 として書き戻されるのは次の保存のときである。
+ */
 public final class PreferencesSettingsAdapter implements SettingsStorePort {
 
     private static final String KEY_SCHEMA = "schemaVersion";
@@ -27,9 +36,13 @@ public final class PreferencesSettingsAdapter implements SettingsStorePort {
     private static final String KEY_DATE = "dateVisibility";
     private static final String KEY_TOPMOST = "windowTopmost";
     private static final String KEY_FONT_POINTS = "fontPoints";
+    private static final String KEY_FONT_FAMILY = "fontFamily";
+    private static final String KEY_FONT_RED = "fontRed";
+    private static final String KEY_FONT_GREEN = "fontGreen";
+    private static final String KEY_FONT_BLUE = "fontBlue";
 
     private static final int SCHEMA_ABSENT = 0;
-    private static final int FONT_POINTS_ABSENT = -1;
+    private static final int INTEGER_ABSENT = -1;
 
     private final Preferences node;
 
@@ -53,10 +66,14 @@ public final class PreferencesSettingsAdapter implements SettingsStorePort {
         if (storedSchema == SCHEMA_ABSENT) {
             return new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.ABSENT);
         }
-        if (storedSchema < 1 || !new SettingsSchemaVersion(storedSchema).isSupported()) {
+        if (storedSchema < SettingsSchemaVersion.EARLIEST_MIGRATABLE.value()) {
             return new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.UNSUPPORTED_SCHEMA);
         }
-        return restore();
+        SettingsSchemaVersion stored = new SettingsSchemaVersion(storedSchema);
+        if (!stored.isMigratable()) {
+            return new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.UNSUPPORTED_SCHEMA);
+        }
+        return restore(stored);
     }
 
     @Override
@@ -68,6 +85,10 @@ public final class PreferencesSettingsAdapter implements SettingsStorePort {
         node.put(KEY_DATE, settings.dateVisibility().name());
         node.put(KEY_TOPMOST, settings.windowTopmost().name());
         node.putInt(KEY_FONT_POINTS, settings.fontSize().points());
+        node.put(KEY_FONT_FAMILY, settings.fontFamily().name());
+        node.putInt(KEY_FONT_RED, settings.fontColor().red());
+        node.putInt(KEY_FONT_GREEN, settings.fontColor().green());
+        node.putInt(KEY_FONT_BLUE, settings.fontColor().blue());
         try {
             node.flush();
         } catch (BackingStoreException failure) {
@@ -76,28 +97,51 @@ public final class PreferencesSettingsAdapter implements SettingsStorePort {
         return new SettingsSaveOutcome.Saved();
     }
 
-    private SettingsLoadOutcome restore() {
+    /**
+     * 版に応じて読む。
+     *
+     * <p>v1 は書体と文字色を持たない。欠けている分は domain の既定値で埋める。推測はしない。
+     */
+    private SettingsLoadOutcome restore(SettingsSchemaVersion stored) {
+        UserSettings carried = readSettingsSharedByEveryVersion();
+        if (carried == null) {
+            return invalidValue();
+        }
+        if (!stored.isSupported()) {
+            return new SettingsLoadOutcome.Restored(carried);
+        }
+        FontFamily family = readFontFamily();
+        if (family == null) {
+            return invalidValue();
+        }
+        FontColor color = readFontColor();
+        if (color == null) {
+            return invalidValue();
+        }
+        return new SettingsLoadOutcome.Restored(new UserSettings(
+                carried.clockFormat(),
+                carried.secondsVisibility(),
+                carried.dateVisibility(),
+                carried.windowTopmost(),
+                family,
+                carried.fontSize(),
+                color));
+    }
+
+    /** v1 から変わっていない 5 項目。書体と文字色は既定値のまま返す。 */
+    private @Nullable UserSettings readSettingsSharedByEveryVersion() {
         ClockFormat clockFormat = lookup(ClockFormat.values(), node.get(KEY_CLOCK_FORMAT, null));
-        if (clockFormat == null) {
-            return invalidValue();
-        }
         SecondsVisibility seconds = lookup(SecondsVisibility.values(), node.get(KEY_SECONDS, null));
-        if (seconds == null) {
-            return invalidValue();
-        }
         DateVisibility date = lookup(DateVisibility.values(), node.get(KEY_DATE, null));
-        if (date == null) {
-            return invalidValue();
-        }
         WindowTopmost topmost = lookup(WindowTopmost.values(), node.get(KEY_TOPMOST, null));
-        if (topmost == null) {
-            return invalidValue();
-        }
         FontSize fontSize = readFontSize();
-        if (fontSize == null) {
-            return invalidValue();
+        if (clockFormat == null || seconds == null) {
+            return null;
         }
-        return new SettingsLoadOutcome.Restored(new UserSettings(clockFormat, seconds, date, topmost, fontSize));
+        if (date == null || topmost == null || fontSize == null) {
+            return null;
+        }
+        return new UserSettings(clockFormat, seconds, date, topmost, FontFamily.DEFAULT, fontSize, FontColor.DEFAULT);
     }
 
     private static SettingsLoadOutcome invalidValue() {
@@ -105,10 +149,30 @@ public final class PreferencesSettingsAdapter implements SettingsStorePort {
     }
 
     private @Nullable FontSize readFontSize() {
-        int points = node.getInt(KEY_FONT_POINTS, FONT_POINTS_ABSENT);
-        return switch (FontSize.of(points)) {
+        return switch (FontSize.of(node.getInt(KEY_FONT_POINTS, INTEGER_ABSENT))) {
             case FontSizeOutcome.Accepted accepted -> accepted.value();
             case FontSizeOutcome.Rejected outOfRange -> null;
+        };
+    }
+
+    private @Nullable FontFamily readFontFamily() {
+        String stored = node.get(KEY_FONT_FAMILY, null);
+        if (stored == null) {
+            return null;
+        }
+        return switch (FontFamily.of(stored)) {
+            case FontFamilyOutcome.Accepted accepted -> accepted.value();
+            case FontFamilyOutcome.Rejected rejected -> null;
+        };
+    }
+
+    private @Nullable FontColor readFontColor() {
+        return switch (FontColor.of(
+                node.getInt(KEY_FONT_RED, INTEGER_ABSENT),
+                node.getInt(KEY_FONT_GREEN, INTEGER_ABSENT),
+                node.getInt(KEY_FONT_BLUE, INTEGER_ABSENT))) {
+            case FontColorOutcome.Accepted accepted -> accepted.value();
+            case FontColorOutcome.Rejected outOfRange -> null;
         };
     }
 

--- a/adapters/preferences/src/test/java/io/github/hideyukimori/neneclock/adapter/preferences/PreferencesSettingsAdapterTest.java
+++ b/adapters/preferences/src/test/java/io/github/hideyukimori/neneclock/adapter/preferences/PreferencesSettingsAdapterTest.java
@@ -7,7 +7,12 @@ import io.github.hideyukimori.neneclock.application.SettingsLoadOutcome;
 import io.github.hideyukimori.neneclock.application.SettingsSaveOutcome;
 import io.github.hideyukimori.neneclock.domain.ClockFormat;
 import io.github.hideyukimori.neneclock.domain.DateVisibility;
+import io.github.hideyukimori.neneclock.domain.FontColor;
+import io.github.hideyukimori.neneclock.domain.FontColorOutcome;
+import io.github.hideyukimori.neneclock.domain.FontFamily;
+import io.github.hideyukimori.neneclock.domain.FontFamilyOutcome;
 import io.github.hideyukimori.neneclock.domain.FontSize;
+import io.github.hideyukimori.neneclock.domain.FontSizeOutcome;
 import io.github.hideyukimori.neneclock.domain.SecondsVisibility;
 import io.github.hideyukimori.neneclock.domain.UserSettings;
 import io.github.hideyukimori.neneclock.domain.WindowTopmost;
@@ -50,7 +55,9 @@ class PreferencesSettingsAdapterTest {
                 SecondsVisibility.HIDDEN,
                 DateVisibility.HIDDEN,
                 WindowTopmost.ENABLED,
-                FontSize.DEFAULT);
+                family("Serif"),
+                FontSize.DEFAULT,
+                color(10, 20, 30));
 
         SettingsSaveOutcome saveOutcome = adapter.save(stored);
 
@@ -59,12 +66,72 @@ class PreferencesSettingsAdapterTest {
     }
 
     @Test
-    void refusesAnUnsupportedSchemaInsteadOfGuessing() {
+    void refusesAFutureSchemaInsteadOfGuessing() {
         node.putInt("schemaVersion", 99);
 
         SettingsLoadOutcome outcome = PreferencesSettingsAdapter.at(node).load();
 
         assertThat(outcome).isEqualTo(new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.UNSUPPORTED_SCHEMA));
+    }
+
+    @Test
+    void migratesVersionOneWithoutLosingTheSettingsItHad() {
+        writeVersionOne(versionOneSettings());
+
+        SettingsLoadOutcome outcome = PreferencesSettingsAdapter.at(node).load();
+
+        assertThat(outcome).isEqualTo(new SettingsLoadOutcome.Restored(versionOneSettings()));
+    }
+
+    @Test
+    void refusesABrokenValueEvenWhenMigratingFromVersionOne() {
+        writeVersionOne(versionOneSettings());
+        node.put("clockFormat", "HOUR_13");
+
+        SettingsLoadOutcome outcome = PreferencesSettingsAdapter.at(node).load();
+
+        assertThat(outcome).isEqualTo(new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.INVALID_VALUE));
+    }
+
+    @Test
+    void doesNotRewriteTheStoreWhileReading() {
+        writeVersionOne(versionOneSettings());
+
+        PreferencesSettingsAdapter.at(node).load();
+
+        assertThat(node.getInt("schemaVersion", 0)).isEqualTo(1);
+    }
+
+    /** v1 で保存されていた設定を v2 の型で表したもの。書体と文字色は既定値になる。 */
+    private static UserSettings versionOneSettings() {
+        return new UserSettings(
+                ClockFormat.HOUR_12,
+                SecondsVisibility.HIDDEN,
+                DateVisibility.HIDDEN,
+                WindowTopmost.ENABLED,
+                FontFamily.DEFAULT,
+                size(96),
+                FontColor.DEFAULT);
+    }
+
+    @Test
+    void refusesAnUnknownFontFamily() {
+        PreferencesSettingsAdapter.at(node).save(UserSettings.defaults());
+        node.put("fontFamily", " ");
+
+        SettingsLoadOutcome outcome = PreferencesSettingsAdapter.at(node).load();
+
+        assertThat(outcome).isEqualTo(new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.INVALID_VALUE));
+    }
+
+    @Test
+    void refusesAColourComponentOutsideTheAllowedRange() {
+        PreferencesSettingsAdapter.at(node).save(UserSettings.defaults());
+        node.putInt("fontGreen", FontColor.MAXIMUM_COMPONENT + 1);
+
+        SettingsLoadOutcome outcome = PreferencesSettingsAdapter.at(node).load();
+
+        assertThat(outcome).isEqualTo(new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.INVALID_VALUE));
     }
 
     @Test
@@ -85,5 +152,30 @@ class PreferencesSettingsAdapterTest {
         SettingsLoadOutcome outcome = PreferencesSettingsAdapter.at(node).load();
 
         assertThat(outcome).isEqualTo(new SettingsLoadOutcome.Defaulted(SettingsLoadFailure.INVALID_VALUE));
+    }
+
+    /**
+     * v1 の保存値を書く。v1 は書体と文字色のキーを持たないので、渡された設定のうち
+     * 当時からある 5 項目だけを書く。
+     */
+    private void writeVersionOne(UserSettings settings) {
+        node.putInt("schemaVersion", 1);
+        node.put("clockFormat", settings.clockFormat().name());
+        node.put("secondsVisibility", settings.secondsVisibility().name());
+        node.put("dateVisibility", settings.dateVisibility().name());
+        node.put("windowTopmost", settings.windowTopmost().name());
+        node.putInt("fontPoints", settings.fontSize().points());
+    }
+
+    private static FontFamily family(String name) {
+        return ((FontFamilyOutcome.Accepted) FontFamily.of(name)).value();
+    }
+
+    private static FontColor color(int red, int green, int blue) {
+        return ((FontColorOutcome.Accepted) FontColor.of(red, green, blue)).value();
+    }
+
+    private static FontSize size(int points) {
+        return ((FontSizeOutcome.Accepted) FontSize.of(points)).value();
     }
 }

--- a/core/application/src/test/java/io/github/hideyukimori/neneclock/application/ClockFaceQueryTest.java
+++ b/core/application/src/test/java/io/github/hideyukimori/neneclock/application/ClockFaceQueryTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.hideyukimori.neneclock.domain.ClockFormat;
 import io.github.hideyukimori.neneclock.domain.DateVisibility;
+import io.github.hideyukimori.neneclock.domain.FontColor;
+import io.github.hideyukimori.neneclock.domain.FontFamily;
 import io.github.hideyukimori.neneclock.domain.FontSize;
 import io.github.hideyukimori.neneclock.domain.SecondsVisibility;
 import io.github.hideyukimori.neneclock.domain.UserSettings;
@@ -70,6 +72,7 @@ class ClockFaceQueryTest {
     }
 
     private static UserSettings settings(ClockFormat format, SecondsVisibility seconds, DateVisibility date) {
-        return new UserSettings(format, seconds, date, WindowTopmost.DISABLED, FontSize.DEFAULT);
+        return new UserSettings(
+                format, seconds, date, WindowTopmost.DISABLED, FontFamily.DEFAULT, FontSize.DEFAULT, FontColor.DEFAULT);
     }
 }

--- a/core/application/src/test/java/io/github/hideyukimori/neneclock/application/SettingsLoadOutcomeTest.java
+++ b/core/application/src/test/java/io/github/hideyukimori/neneclock/application/SettingsLoadOutcomeTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.hideyukimori.neneclock.domain.ClockFormat;
 import io.github.hideyukimori.neneclock.domain.DateVisibility;
+import io.github.hideyukimori.neneclock.domain.FontColor;
+import io.github.hideyukimori.neneclock.domain.FontFamily;
 import io.github.hideyukimori.neneclock.domain.FontSize;
 import io.github.hideyukimori.neneclock.domain.SecondsVisibility;
 import io.github.hideyukimori.neneclock.domain.UserSettings;
@@ -19,7 +21,9 @@ class SettingsLoadOutcomeTest {
                 SecondsVisibility.HIDDEN,
                 DateVisibility.HIDDEN,
                 WindowTopmost.ENABLED,
-                FontSize.DEFAULT);
+                FontFamily.DEFAULT,
+                FontSize.DEFAULT,
+                FontColor.DEFAULT);
 
         SettingsLoadOutcome outcome = new SettingsLoadOutcome.Restored(stored);
 

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontColor.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontColor.java
@@ -1,0 +1,71 @@
+package io.github.hideyukimori.neneclock.domain;
+
+/**
+ * 文字色。RGB の 3 成分だけを持ち、透明度は持たない（FR-044）。
+ *
+ * <p>コンストラクタは非公開で、生成経路は {@link #of(int, int, int)} ただ 1 本（JAV-007）。
+ * 描画に使う色型（{@code java.awt.Color}）への変換は UI の仕事であり、domain は知らない。
+ */
+public final class FontColor {
+
+    /** 各成分の下限。 */
+    public static final int MINIMUM_COMPONENT = 0;
+
+    /** 各成分の上限。 */
+    public static final int MAXIMUM_COMPONENT = 255;
+
+    /** 既定の文字色（黒）。仕様 FR-040 と一致する。 */
+    public static final FontColor DEFAULT = new FontColor(MINIMUM_COMPONENT, MINIMUM_COMPONENT, MINIMUM_COMPONENT);
+
+    private final int red;
+    private final int green;
+    private final int blue;
+
+    private FontColor(int red, int green, int blue) {
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+    }
+
+    /** 各成分を検証して生成する。ここが唯一の生成経路。 */
+    public static FontColorOutcome of(int red, int green, int blue) {
+        if (isOutOfRange(red) || isOutOfRange(green) || isOutOfRange(blue)) {
+            return new FontColorOutcome.Rejected(FontColorRejection.COMPONENT_OUT_OF_RANGE);
+        }
+        return new FontColorOutcome.Accepted(new FontColor(red, green, blue));
+    }
+
+    /** 赤成分。 */
+    public int red() {
+        return red;
+    }
+
+    /** 緑成分。 */
+    public int green() {
+        return green;
+    }
+
+    /** 青成分。 */
+    public int blue() {
+        return blue;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof FontColor color && color.red == red && color.green == green && color.blue == blue;
+    }
+
+    @Override
+    public int hashCode() {
+        return (red * (MAXIMUM_COMPONENT + 1) + green) * (MAXIMUM_COMPONENT + 1) + blue;
+    }
+
+    @Override
+    public String toString() {
+        return "FontColor[" + red + "," + green + "," + blue + "]";
+    }
+
+    private static boolean isOutOfRange(int component) {
+        return component < MINIMUM_COMPONENT || component > MAXIMUM_COMPONENT;
+    }
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontColorOutcome.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontColorOutcome.java
@@ -1,0 +1,25 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import java.util.Objects;
+
+/**
+ * {@link FontColor} 生成の結果。
+ *
+ * <p>期待される失敗を例外ではなく型で表す（JAV-005）。
+ */
+public sealed interface FontColorOutcome {
+
+    /** 検証を通った色。 */
+    record Accepted(FontColor value) implements FontColorOutcome {
+        public Accepted {
+            Objects.requireNonNull(value, "value");
+        }
+    }
+
+    /** 検証で拒否された。理由は閉じた集合で示す。 */
+    record Rejected(FontColorRejection reason) implements FontColorOutcome {
+        public Rejected {
+            Objects.requireNonNull(reason, "reason");
+        }
+    }
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontColorRejection.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontColorRejection.java
@@ -1,0 +1,7 @@
+package io.github.hideyukimori.neneclock.domain;
+
+/** 文字色が拒否された理由。呼び出し側が分岐できるよう、閉じた集合にする（ARC-010）。 */
+public enum FontColorRejection {
+    /** RGB のいずれかの成分が 0..255 の外だった。 */
+    COMPONENT_OUT_OF_RANGE
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontFamily.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontFamily.java
@@ -1,0 +1,71 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import java.util.Objects;
+
+/**
+ * 表示に使う書体名（family name）。
+ *
+ * <p>コンストラクタは非公開で、生成経路は {@link #of(String)} ただ 1 本（JAV-007）。
+ *
+ * <p>🔑 「この実行環境で利用可能かどうか」はこの型の不変条件では**ない**。利用可能性は
+ * 環境依存の事実であり、保存された設定の正しさとは別物である（FR-043）。利用可能な一覧は
+ * ポート経由で application へ渡す。
+ */
+public final class FontFamily {
+
+    /** 書体名の長さの上限。仕様 FR-043 と一致する。 */
+    public static final int MAXIMUM_LENGTH = 64;
+
+    /** 既定の書体。Java の論理フォントであり、どの実行環境にも存在する。 */
+    public static final FontFamily DEFAULT = new FontFamily("Monospaced");
+
+    private final String name;
+
+    private FontFamily(String name) {
+        this.name = name;
+    }
+
+    /** 検証して生成する。ここが唯一の生成経路。 */
+    public static FontFamilyOutcome of(String name) {
+        Objects.requireNonNull(name, "name");
+        if (name.isBlank()) {
+            return new FontFamilyOutcome.Rejected(FontFamilyRejection.BLANK);
+        }
+        if (name.length() > MAXIMUM_LENGTH) {
+            return new FontFamilyOutcome.Rejected(FontFamilyRejection.TOO_LONG);
+        }
+        if (containsControlCharacter(name)) {
+            return new FontFamilyOutcome.Rejected(FontFamilyRejection.UNSUPPORTED_CHARACTER);
+        }
+        return new FontFamilyOutcome.Accepted(new FontFamily(name));
+    }
+
+    /** 書体名。 */
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof FontFamily family && family.name.equals(name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "FontFamily[" + name + "]";
+    }
+
+    private static boolean containsControlCharacter(String name) {
+        for (int index = 0; index < name.length(); index++) {
+            if (Character.isISOControl(name.charAt(index))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontFamilyOutcome.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontFamilyOutcome.java
@@ -1,0 +1,25 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import java.util.Objects;
+
+/**
+ * {@link FontFamily} 生成の結果。
+ *
+ * <p>期待される失敗を例外ではなく型で表す（JAV-005）。
+ */
+public sealed interface FontFamilyOutcome {
+
+    /** 検証を通った書体名。 */
+    record Accepted(FontFamily value) implements FontFamilyOutcome {
+        public Accepted {
+            Objects.requireNonNull(value, "value");
+        }
+    }
+
+    /** 検証で拒否された。理由は閉じた集合で示す。 */
+    record Rejected(FontFamilyRejection reason) implements FontFamilyOutcome {
+        public Rejected {
+            Objects.requireNonNull(reason, "reason");
+        }
+    }
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontFamilyRejection.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/FontFamilyRejection.java
@@ -1,0 +1,11 @@
+package io.github.hideyukimori.neneclock.domain;
+
+/** 書体名が拒否された理由。呼び出し側が分岐できるよう、閉じた集合にする（ARC-010）。 */
+public enum FontFamilyRejection {
+    /** 空、または空白だけだった。 */
+    BLANK,
+    /** 上限より長かった。 */
+    TOO_LONG,
+    /** 書体名に使えない文字（制御文字）を含んでいた。 */
+    UNSUPPORTED_CHARACTER
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/SettingsSchemaVersion.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/SettingsSchemaVersion.java
@@ -4,12 +4,15 @@ package io.github.hideyukimori.neneclock.domain;
  * 永続化された設定のスキーマ版（ARC-009）。
  *
  * <p>版が上がるときは移行規則を同じ変更で持ち込む。読めない版は既定値へ落とすのではなく、
- * 型のある失敗として上へ返す。
+ * 型のある失敗として上へ返す。移行の方針は ADR 0003。
  */
 public record SettingsSchemaVersion(int value) {
 
     /** 現在アプリが書き出す版。 */
-    public static final SettingsSchemaVersion CURRENT = new SettingsSchemaVersion(1);
+    public static final SettingsSchemaVersion CURRENT = new SettingsSchemaVersion(2);
+
+    /** 移行して読める最も古い版。これより古い版は存在しない。 */
+    public static final SettingsSchemaVersion EARLIEST_MIGRATABLE = new SettingsSchemaVersion(1);
 
     public SettingsSchemaVersion {
         if (value < 1) {
@@ -17,8 +20,17 @@ public record SettingsSchemaVersion(int value) {
         }
     }
 
-    /** このアプリが読める版かどうか。 */
+    /** そのまま読める版か（移行が不要か）どうか。 */
     public boolean isSupported() {
         return value == CURRENT.value;
+    }
+
+    /**
+     * 移行して読める版かどうか（判断の根拠は ADR 0003）。
+     *
+     * <p>未来の版は移行できない。推測して読むより、読めないと返すほうが安全である。
+     */
+    public boolean isMigratable() {
+        return value >= EARLIEST_MIGRATABLE.value && value <= CURRENT.value;
     }
 }

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/UserSettings.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/UserSettings.java
@@ -5,21 +5,27 @@ import java.util.Objects;
 /**
  * 利用者設定。すべて不変で、部分的に組み立てられない（JAV-003 / JAV-007）。
  *
- * <p>同じ事実を 2 か所に持たないため、表示に関する設定はこの 1 つの型だけが所有する（ARC-004）。
+ * <p>表示に関する事実の唯一の所有者はこの型である（ARC-004）。同じ事実を 2 か所に持たない。
+ * 成分が 7 つあるのは、それらが「表示設定」という 1 つの概念だからであり、
+ * 名前付きの型にまとめたものが JAV-012 の言う「引数を減らす手段」そのものである。
  */
 public record UserSettings(
         ClockFormat clockFormat,
         SecondsVisibility secondsVisibility,
         DateVisibility dateVisibility,
         WindowTopmost windowTopmost,
-        FontSize fontSize) {
+        FontFamily fontFamily,
+        FontSize fontSize,
+        FontColor fontColor) {
 
     public UserSettings {
         Objects.requireNonNull(clockFormat, "clockFormat");
         Objects.requireNonNull(secondsVisibility, "secondsVisibility");
         Objects.requireNonNull(dateVisibility, "dateVisibility");
         Objects.requireNonNull(windowTopmost, "windowTopmost");
+        Objects.requireNonNull(fontFamily, "fontFamily");
         Objects.requireNonNull(fontSize, "fontSize");
+        Objects.requireNonNull(fontColor, "fontColor");
     }
 
     /** 既定値。仕様 FR-040 と一致する。 */
@@ -29,6 +35,8 @@ public record UserSettings(
                 SecondsVisibility.SHOWN,
                 DateVisibility.SHOWN,
                 WindowTopmost.DISABLED,
-                FontSize.DEFAULT);
+                FontFamily.DEFAULT,
+                FontSize.DEFAULT,
+                FontColor.DEFAULT);
     }
 }

--- a/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/FontColorTest.java
+++ b/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/FontColorTest.java
@@ -1,0 +1,67 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FontColorTest {
+
+    private static final FontColorOutcome.Rejected OUT_OF_RANGE =
+            new FontColorOutcome.Rejected(FontColorRejection.COMPONENT_OUT_OF_RANGE);
+
+    @Test
+    void acceptsComponentsInsideTheAllowedRange() {
+        FontColorOutcome outcome = FontColor.of(10, 20, 30);
+
+        assertThat(outcome).isInstanceOf(FontColorOutcome.Accepted.class);
+        FontColor color = ((FontColorOutcome.Accepted) outcome).value();
+        assertThat(color.red()).isEqualTo(10);
+        assertThat(color.green()).isEqualTo(20);
+        assertThat(color.blue()).isEqualTo(30);
+    }
+
+    @Test
+    void acceptsBothBounds() {
+        int low = FontColor.MINIMUM_COMPONENT;
+        int high = FontColor.MAXIMUM_COMPONENT;
+
+        assertThat(FontColor.of(low, low, low)).isInstanceOf(FontColorOutcome.Accepted.class);
+        assertThat(FontColor.of(high, high, high)).isInstanceOf(FontColorOutcome.Accepted.class);
+    }
+
+    @Test
+    void rejectsARedComponentBelowTheMinimum() {
+        assertThat(FontColor.of(FontColor.MINIMUM_COMPONENT - 1, 0, 0)).isEqualTo(OUT_OF_RANGE);
+    }
+
+    @Test
+    void rejectsAGreenComponentAboveTheMaximum() {
+        assertThat(FontColor.of(0, FontColor.MAXIMUM_COMPONENT + 1, 0)).isEqualTo(OUT_OF_RANGE);
+    }
+
+    @Test
+    void rejectsABlueComponentAboveTheMaximum() {
+        assertThat(FontColor.of(0, 0, FontColor.MAXIMUM_COMPONENT + 1)).isEqualTo(OUT_OF_RANGE);
+    }
+
+    @Test
+    void theDefaultIsAcceptedByItsOwnFactory() {
+        // FontColor.DEFAULT は非公開コンストラクタで直接組み立てられている。
+        // 既定値が自分の検証を通ることを保証しているのはこのテストである（JAV-007 の補完）。
+        assertThat(FontColor.of(FontColor.DEFAULT.red(), FontColor.DEFAULT.green(), FontColor.DEFAULT.blue()))
+                .isInstanceOf(FontColorOutcome.Accepted.class);
+    }
+
+    @Test
+    void comparesByValue() {
+        FontColorOutcome first = FontColor.of(1, 2, 3);
+
+        assertThat(first).isEqualTo(FontColor.of(1, 2, 3));
+        assertThat(first.hashCode()).isEqualTo(FontColor.of(1, 2, 3).hashCode());
+        assertThat(first).isNotEqualTo(FontColor.of(1, 2, 4));
+        assertThat(first).isNotEqualTo(FontColor.of(1, 9, 3));
+        assertThat(first).isNotEqualTo(FontColor.of(9, 2, 3));
+        assertThat(FontColor.DEFAULT).isNotEqualTo("black");
+        assertThat(FontColor.DEFAULT.toString()).contains("0,0,0");
+    }
+}

--- a/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/FontFamilyTest.java
+++ b/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/FontFamilyTest.java
@@ -1,0 +1,62 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FontFamilyTest {
+
+    @Test
+    void acceptsAnOrdinaryFamilyName() {
+        FontFamilyOutcome outcome = FontFamily.of("Noto Sans Mono");
+
+        assertThat(outcome).isInstanceOf(FontFamilyOutcome.Accepted.class);
+        assertThat(((FontFamilyOutcome.Accepted) outcome).value().name()).isEqualTo("Noto Sans Mono");
+    }
+
+    @Test
+    void rejectsABlankName() {
+        assertThat(FontFamily.of("   ")).isEqualTo(new FontFamilyOutcome.Rejected(FontFamilyRejection.BLANK));
+    }
+
+    @Test
+    void rejectsAnOverlongName() {
+        String tooLong = "a".repeat(FontFamily.MAXIMUM_LENGTH + 1);
+
+        assertThat(FontFamily.of(tooLong)).isEqualTo(new FontFamilyOutcome.Rejected(FontFamilyRejection.TOO_LONG));
+    }
+
+    @Test
+    void acceptsANameExactlyAtTheLengthLimit() {
+        String atLimit = "a".repeat(FontFamily.MAXIMUM_LENGTH);
+
+        assertThat(FontFamily.of(atLimit)).isInstanceOf(FontFamilyOutcome.Accepted.class);
+    }
+
+    @Test
+    void rejectsAControlCharacter() {
+        String withBell = "Serif" + (char) 7;
+
+        assertThat(FontFamily.of(withBell))
+                .isEqualTo(new FontFamilyOutcome.Rejected(FontFamilyRejection.UNSUPPORTED_CHARACTER));
+    }
+
+    @Test
+    void theDefaultIsAcceptedByItsOwnFactory() {
+        // FontFamily.DEFAULT は非公開コンストラクタで直接組み立てられている。
+        // 既定値が自分の検証を通ることを保証しているのはこのテストである（JAV-007 の補完）。
+        assertThat(FontFamily.of(FontFamily.DEFAULT.name())).isInstanceOf(FontFamilyOutcome.Accepted.class);
+    }
+
+    @Test
+    void comparesByValue() {
+        FontFamilyOutcome first = FontFamily.of("Serif");
+        FontFamilyOutcome second = FontFamily.of("Serif");
+
+        assertThat(first).isEqualTo(second);
+        assertThat(first.hashCode()).isEqualTo(second.hashCode());
+        assertThat(first).isNotEqualTo(FontFamily.of("SansSerif"));
+        assertThat(FontFamily.DEFAULT).isNotEqualTo(FontFamily.DEFAULT.name());
+        assertThat(FontFamily.DEFAULT.toString()).contains(FontFamily.DEFAULT.name());
+    }
+}

--- a/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/SettingsSchemaVersionTest.java
+++ b/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/SettingsSchemaVersionTest.java
@@ -13,10 +13,22 @@ class SettingsSchemaVersionTest {
     }
 
     @Test
-    void anUnknownFutureVersionIsNotSupported() {
+    void anUnknownFutureVersionIsNeitherSupportedNorMigratable() {
         SettingsSchemaVersion future = new SettingsSchemaVersion(SettingsSchemaVersion.CURRENT.value() + 1);
 
         assertThat(future.isSupported()).isFalse();
+        assertThat(future.isMigratable()).isFalse();
+    }
+
+    @Test
+    void theEarliestVersionIsMigratableButNotSupported() {
+        assertThat(SettingsSchemaVersion.EARLIEST_MIGRATABLE.isMigratable()).isTrue();
+        assertThat(SettingsSchemaVersion.EARLIEST_MIGRATABLE.isSupported()).isFalse();
+    }
+
+    @Test
+    void theCurrentVersionIsMigratable() {
+        assertThat(SettingsSchemaVersion.CURRENT.isMigratable()).isTrue();
     }
 
     @Test

--- a/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/UserSettingsTest.java
+++ b/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/UserSettingsTest.java
@@ -14,7 +14,9 @@ class UserSettingsTest {
         assertThat(settings.secondsVisibility()).isEqualTo(SecondsVisibility.SHOWN);
         assertThat(settings.dateVisibility()).isEqualTo(DateVisibility.SHOWN);
         assertThat(settings.windowTopmost()).isEqualTo(WindowTopmost.DISABLED);
+        assertThat(settings.fontFamily()).isEqualTo(FontFamily.DEFAULT);
         assertThat(settings.fontSize()).isEqualTo(FontSize.DEFAULT);
+        assertThat(settings.fontColor()).isEqualTo(FontColor.DEFAULT);
     }
 
     // 「成分が null の UserSettings を作れない」ことは NullAway が

--- a/docs/PROJECT_LAYOUT.md
+++ b/docs/PROJECT_LAYOUT.md
@@ -81,10 +81,13 @@
 
 意味の正本を持つ。
 
-- 表示に関わる値型（`FontSize`・`SettingsSchemaVersion`）
+- 表示に関わる値型（`FontFamily`・`FontSize`・`FontColor`・`SettingsSchemaVersion`）
 - 閉じた選択肢（`ClockFormat`・`SecondsVisibility`・`DateVisibility`・`WindowTopmost`）
 - 不変の設定値（`UserSettings`）
-- domain 内で共有する拒否理由（`FontSizeRejection`）
+- 拒否理由と結果型（`FontFamilyRejection` / `FontSizeRejection` / `FontColorRejection` と対応する `*Outcome`）
+
+不変条件を持つ値型は `record` ではなく `final class` にする。`record` の正準コンストラクタは
+公開度を下げられず、生成経路が 2 本になるため（JAV-007）。
 
 UI 状態・シリアライズ注釈・永続化・現在時刻を持たない。
 **production 依存の追加そのものをビルドが拒否する**（ARC-003）。
@@ -111,6 +114,7 @@ Swing・`java.util.prefs`・ファイル・ネットワークを知らない。
 
 `SettingsStorePort` の実装をただ 1 つ持つ。保存形式は版を持ち（ARC-009）、
 読めない値は既定値へ黙って落とさず、型のある失敗として返す。
+版の移行もこのモジュールに閉じる（ADR 0003）。`load()` は保存領域を書き換えない。
 
 ### `:ui:swing`
 

--- a/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/ClockPanel.java
+++ b/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/ClockPanel.java
@@ -3,6 +3,7 @@ package io.github.hideyukimori.neneclock.ui.swing;
 import io.github.hideyukimori.neneclock.application.ClockFace;
 import io.github.hideyukimori.neneclock.application.DateLine;
 import io.github.hideyukimori.neneclock.domain.UserSettings;
+import java.awt.Color;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -57,8 +58,15 @@ public final class ClockPanel {
     /** 設定を反映する。 */
     public void renderSettings(UserSettings settings) {
         Objects.requireNonNull(settings, "settings");
+        String family = settings.fontFamily().name();
         int points = settings.fontSize().points();
-        time.setFont(new Font(Font.MONOSPACED, Font.PLAIN, points));
-        date.setFont(new Font(Font.MONOSPACED, Font.PLAIN, Math.max(MINIMUM_DATE_POINTS, points / DATE_FONT_DIVISOR)));
+        Color foreground = new Color(
+                settings.fontColor().red(),
+                settings.fontColor().green(),
+                settings.fontColor().blue());
+        time.setFont(new Font(family, Font.PLAIN, points));
+        time.setForeground(foreground);
+        date.setFont(new Font(family, Font.PLAIN, Math.max(MINIMUM_DATE_POINTS, points / DATE_FONT_DIVISOR)));
+        date.setForeground(foreground);
     }
 }


### PR DESCRIPTION
Issue: #23
目的: 施主要件の書体・文字色を、生の `String` / `int` ではなく不変条件つきの値として持ち、保存形式を壊さずに拡張する。
使った正典経路: 値の検証は domain の唯一のファクトリ、保存形式の知識は `:adapters:preferences` だけ、移行もそこに閉じる（ADR 0003）。
規則 ID: ARC-001 / ARC-009 / ARC-010 / JAV-001 / JAV-002 / JAV-005 / JAV-007 / JAV-012
振る舞い・スキーマの変更: **保存形式 v1 → v2**。v1 は移行して読むので既存の設定は失われない。未来の版は `UNSUPPORTED_SCHEMA`。`load()` は保存領域を書き換えない。

検証（実行したコマンドと結果）:
- `./gradlew check` 成功
- 分岐カバレッジ: `:core:domain` **98%** / `:core:application` **100%**（下限 90%）
- 移行のテスト: v1 の保存値を手で書いてから読み、5 項目が保たれ書体・文字色が既定値になることを確認
- `load()` 後に `schemaVersion` が 1 のままであることを確認（読み取りが副作用を持たない）

**設計上の判断**

- 「その書体がこの環境で利用可能か」を `FontFamily` の不変条件に**入れなかった**。利用可能性は環境依存の事実であって保存値の正しさではない。入れると、別の PC で開いただけで設定が「壊れた値」になる。
- `FontFamily` / `FontColor` を `record` にしなかった。`record` の正準コンストラクタは公開度を下げられず、検証を迂回する生成経路が 2 本目として生まれるため（JAV-007）。`PROJECT_LAYOUT.md` にその理由を明記した。

**スコープ調整**

`FontCatalogPort` と `:adapters:font-catalog` を **#24 へ移した**。この PR の時点では書体一覧を使う場所が無く、入れると「将来使うかもしれない公開 API」を先に置くことになる（`DEVELOPMENT_WORKFLOW.md` のレビューが拒否する項目）。両 Issue にコメントで記録済み。

**ゲートに指摘されて直したもの**

テストの `writeVersionOne(String, String, String, String, int)` が JAV-012 の引数上限 4 に引っかかった。値の組を名前付きの型（`UserSettings`）で渡す形に直した。規則が意図どおり働いた例。

Waivers: none
残るリスク: 設定を変更する GUI はまだ無い（#24）。この PR の時点では既定値と保存済みの値を読むだけ。

Closes #23