### PR TITLE
fix(ui): 毎秒のちらつきを止める。部分再描画と Src の組み合わせが原因 (#55)

### DIFF
--- a/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/ClockPanel.java
+++ b/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/ClockPanel.java
@@ -76,7 +76,13 @@ public final class ClockPanel {
         return panel;
     }
 
-    /** 表示文字列を反映する。 */
+    /**
+     * 表示文字列を反映する。
+     *
+     * <p>🔴 面**全体**を描き直す。文字を変えるだけだと、Swing はラベルの矩形しか塗り直さない。
+     * 地は {@link AlphaComposite#Src} で描いており、これは塗った範囲の画素を**透明度ごと
+     * 置き換える**ので、その長方形だけが消えて描き直され、境目が毎秒ちらついた（FR-002 / Issue #55）。
+     */
     public void renderFace(ClockFace face) {
         Objects.requireNonNull(face, "face");
         time.setText(face.time());
@@ -87,6 +93,7 @@ public final class ClockPanel {
             }
             case DateLine.Hidden hidden -> date.setVisible(false);
         }
+        panel.repaint();
     }
 
     /** 設定を反映する。半透明で描けない環境では、地を不透明にして描く。 */


### PR DESCRIPTION
Closes #55

## 原因

#49（透明度）で持ち込んだ描き方が、**部分再描画と噛み合っていなかった**。

```java
canvas.setComposite(AlphaComposite.Src);   // 透明度ごと置き換える（破壊的）
canvas.fill(角丸矩形);
```

1. 毎秒 `time.setText(...)` すると、Swing は**ラベルの矩形だけ**を再描画する
2. その切り取られた範囲で `Src` が走り、画素を**透明度ごと置き換える**
3. 周りは前のフレームのまま残るので、長方形の境目が毎秒見える

不透明だった頃（#49 以前）は `SrcOver` で塗り重ねていたので出なかった。
**半透明にしたことで、部分再描画に耐えない描き方になっていた。**

## `Src` は残す

角の外側を透明にするために要る。`SrcOver` にすると、半透明の色が再描画のたびに塗り重なって
少しずつ濃くなり、透明度が意味を失う。**問題は合成方法ではなく、塗り直す範囲のほう。**

## 直しかた

刻みごとに**面全体**を描き直す（`renderFace` の最後で `panel.repaint()`）。
1 秒に 1 回、550x260 を塗り直すだけなので、費用は無視できる。

## 検証

```text
./gradlew check          BUILD SUCCESSFUL
```

⚠️ **ちらつきそのものは私の側から見えない。** 1 フレームの現象で、WSLg は rootless なので
デスクトップを撮れない。連続キャプチャでフレームが安定していることまでは確かめた。
**実機で 1 分ほど見て、止まったか確かめてほしい。**

まだ出るようなら、次の疑いは窓そのものの再描画経路（半透明の窓の blit）で、
そのときは自前の裏画面へ描いてから 1 枚で貼る形にする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cAh2VG4Bg64e3pnJvcM8x