### PR TITLE
build(dist): Windows インストーラー（jpackage の MSI）を CI の Windows ランナーで作り、GitHub Release で配る (#66)

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,0 +1,69 @@
+# QLT-001 / QLT-005: 配布の手順は Gradle task（packageInstaller）に閉じる。
+# ここは Windows ランナーで同じ task を呼び、できたものを置くだけ。品質判断は持たない（ADR 0013）。
+name: Windows installer
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+  # 配布の結線に触る PR では、マージ前に Windows で MSI ができることを確かめる。
+  pull_request:
+    paths:
+      - ".github/workflows/windows-installer.yml"
+      - "app/build.gradle.kts"
+      - "app/src/main/java/io/github/hideyukimori/neneclock/app/AppIconFiles.java"
+      - "app/src/main/java/io/github/hideyukimori/neneclock/app/IcoFile.java"
+      - "gradle.properties"
+
+permissions:
+  contents: read
+
+jobs:
+  installer:
+    name: installer
+    runs-on: windows-2025
+    timeout-minutes: 30
+    permissions:
+      # タグのときだけ Release に添付する。それ以外の run では書き込みを使わない。
+      contents: write
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
+          validate-wrappers: true
+
+      - name: Build the installer with the canonical task
+        run: ./gradlew packageInstaller --stacktrace
+
+      - name: Keep the installer as a run artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nene-clock-windows-installer
+          path: |
+            app/build/installer/*.msi
+            app/build/installer/*.sha256
+          if-no-files-found: error
+
+      - name: Attach to the GitHub Release (tags only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          gh release create "$GITHUB_REF_NAME"
+          app/build/installer/*.msi app/build/installer/*.sha256
+          --title "NeNe Clock $GITHUB_REF_NAME" --generate-notes

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Both scripts are idempotent. `tools/uninstall-desktop-entry.sh` removes what the
 Windows users do not need WSL or a JDK: download the `.msi` from the
 [Releases page](https://github.com/hideyukiMORI/nene-clock/releases) and double-click it.
 It installs per user (no admin prompt), adds a Start Menu entry and a desktop shortcut, and
-re-installing a newer version upgrades in place. The installer is unsigned for now, so
+re-installing a newer version upgrades in place. The installer is deliberately unsigned, so
 SmartScreen shows "Windows protected your PC" on first launch — choose *More info → Run anyway*.
 
 The installer is built by **one Gradle task** on a Windows runner ([ADR 0013](docs/adr/0013-windows-is-distributed-as-a-jpackage-msi.md)):

--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ WSLg's own icon has a penguin badge stamped onto it.
 
 Both scripts are idempotent. `tools/uninstall-desktop-entry.sh` removes what they installed.
 
+## Windows installer
+
+Windows users do not need WSL or a JDK: download the `.msi` from the
+[Releases page](https://github.com/hideyukiMORI/nene-clock/releases) and double-click it.
+It installs per user (no admin prompt), adds a Start Menu entry and a desktop shortcut, and
+re-installing a newer version upgrades in place. The installer is unsigned for now, so
+SmartScreen shows "Windows protected your PC" on first launch — choose *More info → Run anyway*.
+
+The installer is built by **one Gradle task** on a Windows runner ([ADR 0013](docs/adr/0013-windows-is-distributed-as-a-jpackage-msi.md)):
+
+```bash
+./gradlew packageInstaller      # Windows: app/build/installer/*.msi (+ .sha256)
+                                # elsewhere: an app-image, to prove the wiring
+```
+
+`jpackage` bundles a trimmed runtime, the module set comes from `jdeps`, and the `.ico`
+is written from `AppIcon` like every other icon. Pushing a `v*` tag attaches the MSI to a
+GitHub Release; running the *Windows installer* workflow by hand keeps it as a run artifact.
+
 ## Project layout
 
 ```text

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,8 @@
 import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
+import java.io.ByteArrayOutputStream
+import java.security.MessageDigest
+import javax.inject.Inject
+import org.gradle.process.ExecOperations
 
 plugins {
     id("neneclock.java-conventions")
@@ -42,4 +46,99 @@ tasks.register<JavaExec>("writeAppIcons") {
     classpath = sourceSets["main"].runtimeClasspath
     systemProperty("java.awt.headless", "true")
     args(layout.buildDirectory.dir("icons").get().asFile.path)
+}
+
+// 🔑 配布物（インストーラー）を作る経路は 1 つ（ARC-012 / QLT-005 / ADR 0013）。
+//    CI の Windows ランナーもこの task を呼ぶだけで、ワークフローに手順を書かない。
+//    Windows では MSI を作る。ほかの OS では同じ結線で app-image を作り、
+//    jar・main クラス・アイコン・モジュール集合が正しいことを起動して証明できる。
+//    モジュール集合は jdeps から機械的に求める。手で書くと、足りないときに実行時まで分からない。
+abstract class PackageInstaller : DefaultTask() {
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    @get:InputDirectory
+    abstract val libDirectory: DirectoryProperty
+
+    @get:InputDirectory
+    abstract val iconDirectory: DirectoryProperty
+
+    @get:InputFile
+    abstract val licenseFile: RegularFileProperty
+
+    @get:Input
+    abstract val jdkHome: Property<String>
+
+    @get:Input
+    abstract val mainClass: Property<String>
+
+    @get:Input
+    abstract val mainJarName: Property<String>
+
+    @get:Input
+    abstract val appVersion: Property<String>
+
+    @get:OutputDirectory
+    abstract val destination: DirectoryProperty
+
+    @TaskAction
+    fun run() {
+        val onWindows = System.getProperty("os.name").startsWith("Windows")
+        val bin = File(jdkHome.get(), "bin")
+        val lib = libDirectory.get().asFile
+        val jars = lib.listFiles { file -> file.name.endsWith(".jar") }!!.sorted()
+        val modules = ByteArrayOutputStream().also { captured ->
+            execOperations.exec {
+                executable = File(bin, "jdeps").path
+                args("--print-module-deps", "--ignore-missing-deps", "--multi-release", "21", "--class-path", File(lib, "*").path)
+                args(jars.map { it.path })
+                standardOutput = captured
+            }
+        }.toString(Charsets.UTF_8).trim()
+        val out = destination.get().asFile
+        out.deleteRecursively()
+        out.mkdirs()
+        val icon = File(iconDirectory.get().asFile, if (onWindows) "nene-clock.ico" else "nene-clock-256.png")
+        execOperations.exec {
+            executable = File(bin, "jpackage").path
+            args("--type", if (onWindows) "msi" else "app-image")
+            args("--name", "NeNe Clock")
+            args("--app-version", appVersion.get())
+            args("--vendor", "hideyukiMORI")
+            args("--description", "A quiet desktop clock")
+            args("--input", lib.path)
+            args("--main-jar", mainJarName.get())
+            args("--main-class", mainClass.get())
+            args("--icon", icon.path)
+            args("--add-modules", modules)
+            args("--dest", out.path)
+            if (onWindows) {
+                args("--license-file", licenseFile.get().asFile.path)
+                args("--win-menu", "--win-shortcut", "--win-per-user-install")
+                // 入れ直しを「上書き」にする鍵。変えると別製品として並んで入る。
+                args("--win-upgrade-uuid", "ea39da0b-604d-46ab-8ac1-69d155faaec8")
+            }
+        }
+        out.listFiles { file -> file.isFile }!!.forEach { file ->
+            val digest = MessageDigest.getInstance("SHA-256").digest(file.readBytes())
+            val hex = digest.joinToString("") { byte -> "%02x".format(byte) }
+            File(out, file.name + ".sha256").writeText("$hex  ${file.name}\n")
+        }
+        logger.lifecycle("modules: {}", modules)
+        logger.lifecycle("installer: {}", out.listFiles()!!.joinToString { it.name })
+    }
+}
+
+tasks.register<PackageInstaller>("packageInstaller") {
+    group = "distribution"
+    description = "インストーラーを作る（Windows は MSI、それ以外は app-image で結線を確かめる）"
+    dependsOn(tasks.named("installDist"), tasks.named("writeAppIcons"))
+    libDirectory.set(layout.buildDirectory.dir("install/app/lib"))
+    iconDirectory.set(layout.buildDirectory.dir("icons"))
+    licenseFile.set(rootProject.layout.projectDirectory.file("LICENSE"))
+    jdkHome.set(javaToolchains.launcherFor(java.toolchain).map { it.metadata.installationPath.asFile.absolutePath })
+    mainClass.set(application.mainClass)
+    mainJarName.set(tasks.named<Jar>("jar").flatMap { it.archiveFileName })
+    appVersion.set(project.version.toString())
+    destination.set(layout.buildDirectory.dir("installer"))
 }

--- a/app/src/main/java/io/github/hideyukimori/neneclock/app/AppIconFiles.java
+++ b/app/src/main/java/io/github/hideyukimori/neneclock/app/AppIconFiles.java
@@ -4,16 +4,22 @@ import io.github.hideyukimori.neneclock.ui.swing.AppIcon;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.List;
 import javax.imageio.ImageIO;
 
 /**
- * アイコンを PNG として書き出す。**配布物を作るときだけ**使う入口。
+ * アイコンを PNG と ICO として書き出す。**配布物を作るときだけ**使う入口。
  *
  * <p>デスクトップエントリ（{@code .desktop}）はアイコンをファイルで指すので、画像が要る。
  * だからといって画像をリポジトリに置くと、**描いている絵と置いた絵が別々に存在する**ことになり、
  * 片方だけ古くなる。ここで {@link AppIcon} から書き出せば、絵の正本は 1 つのままである。
+ *
+ * <p>PNG は {@code .desktop} が指す。ICO は Windows のインストーラー（{@code jpackage}）と
+ * デスクトップのショートカットが指す。どちらも同じ {@link AppIcon} から出る。
  *
  * <p>アプリの入口ではない。{@code ./gradlew writeAppIcons} からだけ呼ばれる。
  */
@@ -23,7 +29,7 @@ public final class AppIconFiles {
 
     private AppIconFiles() {}
 
-    /** 第 1 引数の場所へ PNG を書き出す。 */
+    /** 第 1 引数の場所へ PNG と ICO を書き出す。 */
     public static void main(String[] arguments) {
         if (arguments.length != 1) {
             System.err.println("usage: AppIconFiles <出力先ディレクトリ>");
@@ -45,12 +51,19 @@ public final class AppIconFiles {
     }
 
     private static void write(File directory) throws IOException {
-        List<Image> images = AppIcon.images();
-        for (Image image : images) {
-            BufferedImage drawn = (BufferedImage) image;
-            File file = new File(directory, "nene-clock-" + drawn.getWidth() + ".png");
-            ImageIO.write(drawn, "png", file);
+        List<BufferedImage> drawn = new ArrayList<>();
+        for (Image image : AppIcon.images()) {
+            drawn.add((BufferedImage) image);
+        }
+        for (BufferedImage image : drawn) {
+            File file = new File(directory, "nene-clock-" + image.getWidth() + ".png");
+            ImageIO.write(image, "png", file);
             System.out.println(file.getPath());
         }
+        File ico = new File(directory, "nene-clock.ico");
+        try (OutputStream out = new FileOutputStream(ico)) {
+            IcoFile.write(drawn, out);
+        }
+        System.out.println(ico.getPath());
     }
 }

--- a/app/src/main/java/io/github/hideyukimori/neneclock/app/IcoFile.java
+++ b/app/src/main/java/io/github/hideyukimori/neneclock/app/IcoFile.java
@@ -1,0 +1,82 @@
+package io.github.hideyukimori.neneclock.app;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import javax.imageio.ImageIO;
+
+/**
+ * Windows のアイコン（{@code .ico}）を書く。
+ *
+ * <p>ICO は「目次 ＋ 画像の列」だけの形式で、Vista 以降は各画像を PNG のまま埋め込める。
+ * だから PNG を書ける {@link ImageIO} があれば、外の道具（ImageMagick）は要らない。
+ * 目次はリトルエンディアンで書く。{@link DataOutputStream} はビッグエンディアンなので、
+ * 数値はここでバイトに割る。
+ *
+ * <p>256px は幅・高さの欄に 0 と書く決まりである（1 バイトに 256 が入らないため）。
+ */
+final class IcoFile {
+
+    private static final int RESERVED = 0;
+    private static final int TYPE_ICON = 1;
+    private static final int COLOUR_PLANES = 1;
+    private static final int BITS_PER_PIXEL = 32;
+    private static final int HEADER_BYTES = 6;
+    private static final int ENTRY_BYTES = 16;
+    private static final int LARGEST_ENCODABLE_SIDE = 255;
+    private static final int BYTE_MASK = 0xFF;
+    private static final int BITS_PER_BYTE = 8;
+
+    private IcoFile() {}
+
+    /** 与えられた画像を 1 つの ICO として書く。順序はそのまま保つ。 */
+    static void write(List<BufferedImage> images, OutputStream destination) throws IOException {
+        List<byte[]> encoded = new ArrayList<>();
+        for (BufferedImage image : images) {
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            ImageIO.write(image, "png", buffer);
+            encoded.add(buffer.toByteArray());
+        }
+        DataOutputStream out = new DataOutputStream(destination);
+        writeShort(out, RESERVED);
+        writeShort(out, TYPE_ICON);
+        writeShort(out, images.size());
+        int offset = HEADER_BYTES + ENTRY_BYTES * images.size();
+        for (int index = 0; index < images.size(); index++) {
+            BufferedImage image = images.get(index);
+            byte[] bytes = encoded.get(index);
+            out.writeByte(sideByte(image.getWidth()));
+            out.writeByte(sideByte(image.getHeight()));
+            out.writeByte(RESERVED);
+            out.writeByte(RESERVED);
+            writeShort(out, COLOUR_PLANES);
+            writeShort(out, BITS_PER_PIXEL);
+            writeInt(out, bytes.length);
+            writeInt(out, offset);
+            offset += bytes.length;
+        }
+        for (byte[] bytes : encoded) {
+            out.write(bytes);
+        }
+        out.flush();
+    }
+
+    private static int sideByte(int side) {
+        return side > LARGEST_ENCODABLE_SIDE ? 0 : side;
+    }
+
+    private static void writeShort(DataOutputStream out, int value) throws IOException {
+        out.writeByte(value & BYTE_MASK);
+        out.writeByte((value >>> BITS_PER_BYTE) & BYTE_MASK);
+    }
+
+    private static void writeInt(DataOutputStream out, int value) throws IOException {
+        for (int shift = 0; shift < Integer.SIZE; shift += BITS_PER_BYTE) {
+            out.writeByte((value >>> shift) & BYTE_MASK);
+        }
+    }
+}

--- a/app/src/test/java/io/github/hideyukimori/neneclock/app/IcoFileTest.java
+++ b/app/src/test/java/io/github/hideyukimori/neneclock/app/IcoFileTest.java
@@ -1,0 +1,54 @@
+package io.github.hideyukimori.neneclock.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.hideyukimori.neneclock.ui.swing.AppIcon;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class IcoFileTest {
+
+    private static final byte[] PNG_SIGNATURE = {(byte) 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+
+    @Test
+    void writesAnIcoDirectoryWhosePointersLandOnPngImages() throws IOException {
+        List<BufferedImage> images =
+                AppIcon.images().stream().map(image -> (BufferedImage) image).toList();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        IcoFile.write(images, out);
+        byte[] ico = out.toByteArray();
+
+        assertThat(ico).startsWith((byte) 0, (byte) 0, (byte) 1, (byte) 0, (byte) images.size(), (byte) 0);
+        for (int index = 0; index < images.size(); index++) {
+            int entry = 6 + 16 * index;
+            int side = images.get(index).getWidth();
+            assertThat(Byte.toUnsignedInt(ico[entry])).isEqualTo(side == 256 ? 0 : side);
+            assertThat(Byte.toUnsignedInt(ico[entry + 1])).isEqualTo(side == 256 ? 0 : side);
+            int size = littleEndianInt(ico, entry + 8);
+            int offset = littleEndianInt(ico, entry + 12);
+            assertThat(offset + size).isLessThanOrEqualTo(ico.length);
+            byte[] head = new byte[PNG_SIGNATURE.length];
+            System.arraycopy(ico, offset, head, 0, head.length);
+            assertThat(head).isEqualTo(PNG_SIGNATURE);
+        }
+    }
+
+    @Test
+    void theBundledIconHasEverySizeWindowsAsksFor() {
+        List<Integer> sides = AppIcon.images().stream()
+                .map(image -> ((BufferedImage) image).getWidth())
+                .toList();
+        assertThat(sides).contains(16, 32, 48, 256);
+    }
+
+    private static int littleEndianInt(byte[] bytes, int at) {
+        return Byte.toUnsignedInt(bytes[at])
+                | Byte.toUnsignedInt(bytes[at + 1]) << 8
+                | Byte.toUnsignedInt(bytes[at + 2]) << 16
+                | Byte.toUnsignedInt(bytes[at + 3]) << 24;
+    }
+}

--- a/docs/adr/0013-windows-is-distributed-as-a-jpackage-msi.md
+++ b/docs/adr/0013-windows-is-distributed-as-a-jpackage-msi.md
@@ -1,0 +1,60 @@
+# ADR 0013 — Windows へは jpackage の MSI で配る。作るのは CI の Windows ランナー
+
+- 状態: 受理
+- 日付: 2026-09-04
+- Issue: #66
+- 影響する規則: QLT-001 / QLT-005 / ARC-012 / ADR 0005 / FR-030
+
+## 文脈
+
+施主要件: Windows からインストーラーで入れたい。GitHub で配りたい。
+
+いまの配布経路は WSL の中に `/opt/nene-clock` を置き、WSLg がショートカットを作るもの（#50）だけである。
+利用者に WSL と JDK を要求するので、配布とは呼べない。
+さらに、ちらつき（#64）は WSLg の合成層の事象であり、ネイティブの Windows 窓なら起きない可能性が高い。
+
+## 決定
+
+1. **JDK 同梱の `jpackage` で MSI を作る。** 実行環境は `jlink` で刻んで同梱し、利用者に Java を要求しない
+2. **作るのは GitHub Actions の Windows ランナー。** `jpackage` は動いている OS 向けしか作れない（クロスビルド不可）
+3. **手順は Gradle task `packageInstaller` に閉じる**（QLT-005）。ワークフローはその task を呼び、できたものを置くだけ。
+   Windows 以外では同じ task が app-image を作り、結線（jar・main クラス・アイコン・モジュール集合）が正しいことを
+   起動して証明できる
+4. **モジュール集合は `jdeps` から機械的に求める。** 手で書くと、足りないモジュールは実行時まで分からない
+5. **`.ico` は実装（`AppIcon`）から書き出す**（#46 と同じ原則）。ImageMagick への依存は消す
+6. **MSI の upgrade UUID を固定する。** 入れ直しが上書きになる。変えると別製品として並んで入る
+7. **配布は GitHub Release に MSI と SHA-256 を添付する。** `v*` タグを打つと自動で添付される。
+   手動起動（workflow_dispatch）では run の成果物として落とせる（施主の実機確認用）
+8. 版は `gradle.properties` の `version` 1 か所。MSI は数字 3 つの形しか受けない
+
+## 却下した選択肢
+
+| 選択肢 | 却下の理由 |
+| --- | --- |
+| Inno Setup / NSIS | 外の道具と別のスクリプト言語が増える。`jpackage` は JDK にあり、方法が 1 つで済む |
+| MSIX / winget / Microsoft Store | 署名が前提。証明書を持ってから別の ADR で問い直す |
+| zip を配って「JDK を入れて `bin/app` を叩け」 | 利用者に JDK を要求する。インストーラーという要件に応えていない |
+| WSL から Windows 向けをクロスビルド | `jpackage` にその機能が無い |
+| ワークフローの中で `jpackage` を直接叩く | 手順が CI 専用のシェルになり、ローカルで再現できない（QLT-005） |
+| `--add-modules` を手で書く | 足りないときに実行時の `ClassNotFoundException` でしか分からない |
+| ImageMagick で `.ico` を作り続ける | 作り方が 2 つになり、片方だけ古くなる（ARC-012）。ランナーにあるとも限らない |
+
+## 強制
+
+- **active**: `packageInstaller` が Linux で app-image を作り、起動できる（gate-proofs 第 20 節）
+- **planned**: Windows ランナーで MSI ができ、施主の実機で入る。**ネイティブの Windows 窓でちらつきが起きないか**もそこで見る
+- **planned**: コード署名。無い間は SmartScreen の警告が出る（「詳細情報」→「実行」で通る）
+
+## 結果
+
+得られるもの:
+
+- 利用者は MSI をダブルクリックするだけ。JDK も WSL も要らない
+- Windows 側の設定はレジストリ（`HKCU\Software\JavaSoft\Prefs`）に入る。WSL 側の設定とは別になる
+- ちらつきの原因だった合成層（WSLg）を通らない
+
+失うもの:
+
+- 配布物は 40〜60 MB 程度になる（実行環境を同梱するため）
+- 署名が無い間、初回起動で SmartScreen に止められる
+- WSL 側と Windows 側で設定が共有されない

--- a/docs/adr/0013-windows-is-distributed-as-a-jpackage-msi.md
+++ b/docs/adr/0013-windows-is-distributed-as-a-jpackage-msi.md
@@ -32,7 +32,7 @@
 | 選択肢 | 却下の理由 |
 | --- | --- |
 | Inno Setup / NSIS | 外の道具と別のスクリプト言語が増える。`jpackage` は JDK にあり、方法が 1 つで済む |
-| MSIX / winget / Microsoft Store | 署名が前提。証明書を持ってから別の ADR で問い直す |
+| MSIX / winget / Microsoft Store | 署名が前提。署名しないと決めたので採れない |
 | zip を配って「JDK を入れて `bin/app` を叩け」 | 利用者に JDK を要求する。インストーラーという要件に応えていない |
 | WSL から Windows 向けをクロスビルド | `jpackage` にその機能が無い |
 | ワークフローの中で `jpackage` を直接叩く | 手順が CI 専用のシェルになり、ローカルで再現できない（QLT-005） |
@@ -43,7 +43,11 @@
 
 - **active**: `packageInstaller` が Linux で app-image を作り、起動できる（gate-proofs 第 20 節）
 - **planned**: Windows ランナーで MSI ができ、施主の実機で入る。**ネイティブの Windows 窓でちらつきが起きないか**もそこで見る
-- **planned**: コード署名。無い間は SmartScreen の警告が出る（「詳細情報」→「実行」で通る）
+- **署名はしない（施主決定 2026-09-04）。** SmartScreen の警告は出るが、「詳細情報」→「実行」で通る。
+  コード署名証明書は認証局から買う（OV で年数万円・鍵はハードウェアかクラウド署名）か、
+  Microsoft の Azure Trusted Signing（月額制・法人は設立 3 年以上の条件）か、Certum の OSS 向けかになる。
+  署名しても評判が溜まるまで警告は消えない。いまの配布規模ではその費用と手間に見合わない。
+  再検討するなら、CI から署名できるクラウド方式（Trusted Signing / eSigner / KeyLocker）を前提にする
 
 ## 結果
 
@@ -56,5 +60,5 @@
 失うもの:
 
 - 配布物は 40〜60 MB 程度になる（実行環境を同梱するため）
-- 署名が無い間、初回起動で SmartScreen に止められる
+- 初回起動で SmartScreen に止められる（署名しないと決めた）
 - WSL 側と Windows 側で設定が共有されない

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,4 @@ ADR は「なぜそう決めたか」「何を却下したか」を書く。
 | [0010](0010-no-button-that-does-nothing.md) | 押しても何も起きないボタンを置かない（移動アイコンをやめる） | 受理 |
 | [0011](0011-transparency-is-asked-for-not-assumed.md) | 半透明は「頼んで、断られたら諦める」 | 置換（→ 0012） |
 | [0012](0012-transparency-is-dropped-the-artefact-is-not-ours.md) | 透明度をやめる。ちらつきはアプリの外にあった | 受理 |
+| [0013](0013-windows-is-distributed-as-a-jpackage-msi.md) | Windows へは jpackage の MSI で配る。作るのは CI の Windows ランナー | 受理 |

--- a/docs/quality/gate-proofs.md
+++ b/docs/quality/gate-proofs.md
@@ -687,7 +687,42 @@ ADR 0012 は「窓は常に不透明。角丸は `setShape` の切り抜きへ�
 ちらつきそのものは `import` では撮れない（窓自身の画素ではなく、合成層の事象。第 17 節）。
 **消えたかどうかは施主の画面でしか確かめられない。** マージ前に見てもらう。
 
-## 20. まだ証明していないもの
+## 20. Windows インストーラーの結線（Issue #66 / ADR 0013）
+
+### 20.1 Linux で app-image を作り、起動した（2026-09-04・WSLg・`DISPLAY=:0`）
+
+`jpackage` は動いている OS 向けしか作れないので、MSI そのものは Windows ランナーでしか作れない。
+その代わり**同じ task**（`packageInstaller`）が Linux では app-image を作る。jar・main クラス・アイコン・
+モジュール集合の結線はここで証明できる。
+
+```text
+$ ./gradlew packageInstaller
+modules: java.base,java.desktop,java.prefs            ← jdeps が求めた集合（手で書いていない）
+installer: NeNe Clock                                  ← app/build/installer/NeNe Clock/
+$ grep MODULES "app/build/installer/NeNe Clock/lib/runtime/release"
+MODULES="java.base java.datatransfer java.xml java.prefs java.desktop"
+$ "app/build/installer/NeNe Clock/bin/NeNe Clock" &
+$ xwininfo -id 0x800004 | grep Depth
+  Depth: 24
+```
+
+窓が出た。同梱書体で描かれ、保存済みの設定（背景 `#1A1917` 系・文字色ピンク）が読めている。
+つまり刻んだ実行環境に `java.desktop` と `java.prefs` が入っており、フォントの読み込みも通っている。
+大きさは 88 MB（Linux・非圧縮。MSI は圧縮される）。
+
+### 20.2 `.ico` は実装から出る
+
+`writeAppIcons` が PNG 8 枚に加えて `nene-clock.ico` を書く。単体テスト（`IcoFileTest`）が
+目次の先頭 6 バイト・各エントリの幅と高さ・各ポインタの先が PNG 署名であることを見る。
+`tools/place-windows-shortcut.sh` は ImageMagick をやめ、この `.ico` を使う。
+
+### 20.3 まだ証明していないこと
+
+- Windows ランナーで MSI ができること（PR の workflow で初めて走る）
+- 施主の Windows 実機で入って起動すること。**ネイティブの窓でちらつきが起きないか**もそこで見る
+- 署名は無い。SmartScreen の警告が出る
+
+## 21. まだ証明していないもの
 
 🔴 **ここに書いていないものは、証明されていない。**
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,6 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=false
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8
+
+# 配布物の版（jpackage の --app-version）。MSI は数字 3 つの形しか受けない。
+version=0.2.0

--- a/tools/install-desktop-entry.sh
+++ b/tools/install-desktop-entry.sh
@@ -26,7 +26,7 @@ echo "==> $PREFIX へ置く"
 rm -rf "$PREFIX"
 mkdir -p "$PREFIX"
 cp -r "$REPO/app/build/install/app/." "$PREFIX/"
-cp "$REPO/app/build/icons/"*.png "$PREFIX/"
+cp "$REPO/app/build/icons/"nene-clock* "$PREFIX/"   # PNG と .ico（どちらも AppIcon から書き出したもの）
 chmod -R a+rX "$PREFIX"
 chmod a+x "$PREFIX/bin/app"
 

--- a/tools/place-windows-shortcut.sh
+++ b/tools/place-windows-shortcut.sh
@@ -6,7 +6,7 @@
 #   ここでやるのは「それをデスクトップへ複製し、アイコンを差し替える」ことだけである。
 #
 # 🔴 WSLg が作るアイコンには**ペンギンが合成される**（Linux アプリの目印）。
-#    製品のアイコンをそのまま出したいので、自前の .ico を作って指し直す。
+#    製品のアイコンをそのまま出したいので、実装から書き出した .ico を指し直す。
 #
 # 🔴 Windows 側のパス操作は PowerShell に閉じる。日本語のフォルダ名（「デスクトップ」など）は、
 #    powershell.exe の出力を bash 側で受けると文字化けするため（実測）。
@@ -29,16 +29,16 @@ if [ ! -d "$PREFIX" ]; then
   exit 1
 fi
 
-echo "==> アイコン（.ico）を作って Windows 側へ置く"
+echo "==> アイコン（.ico）を Windows 側へ置く"
+# .ico は AppIconFiles が実装から書き出したもの（install-desktop-entry.sh が $PREFIX へ置く）。
+# 以前は ImageMagick で PNG から作っていたが、作り方が 2 つあると片方だけ古くなる（#66）。
 LOCAL_APPDATA="$("$POWERSHELL" -NoProfile -Command '$env:LOCALAPPDATA' | tr -d '\r')"
 ICON_DIR="$(wslpath -u "$LOCAL_APPDATA")/NeNeClock"
 mkdir -p "$ICON_DIR"
-if command -v convert > /dev/null; then
-  convert "$PREFIX"/nene-clock-16.png "$PREFIX"/nene-clock-24.png "$PREFIX"/nene-clock-32.png \
-          "$PREFIX"/nene-clock-48.png "$PREFIX"/nene-clock-64.png "$PREFIX"/nene-clock-128.png \
-          "$PREFIX"/nene-clock-256.png "$ICON_DIR/nene-clock.ico"
+if [ -f "$PREFIX/nene-clock.ico" ]; then
+  cp "$PREFIX/nene-clock.ico" "$ICON_DIR/nene-clock.ico"
 else
-  echo "  ImageMagick が無いので、アイコンは WSLg のもの（ペンギンつき）のままにする。" >&2
+  echo "  $PREFIX/nene-clock.ico が無い（古い install）。install-desktop-entry.sh を入れ直すこと。アイコンは WSLg のもの（ペンギンつき）のままにする。" >&2
 fi
 
 echo "==> デスクトップへ置き、アイコンを指し直す"


### PR DESCRIPTION
Closes #66

## 何を

- **`./gradlew packageInstaller`** 1 本でインストーラーを作る。Windows では MSI、それ以外では app-image（結線の証明用）。モジュール集合は `jdeps` から機械的に求め、MSI の upgrade UUID を固定し、SHA-256 を隣に書く
- **`.ico` は実装（`AppIcon`）から書き出す**（`IcoFile`・PNG 埋め込み形式・単体テストつき）。`place-windows-shortcut.sh` の ImageMagick 依存を消した
- **`windows-installer.yml`**: Windows ランナーで同じ task を呼び、成果物に上げる。`v*` タグでは GitHub Release に添付。配布の結線に触る PR でも走る
- `gradle.properties` に `version=0.2.0`。ADR 0013・README（Windows installer の節）・gate-proofs 第 20 節

## なぜ

施主要件: Windows からインストーラーで入れたい。GitHub で配りたい。いまの配布経路（WSL の `/opt` ＋ WSLg のショートカット）は利用者に WSL と JDK を要求する。ネイティブの Windows 窓なら、WSLg の合成層で起きていたちらつき（#64）を通らない。

## 却下した選択肢

ADR 0013 の表を参照。Inno Setup / NSIS、MSIX / winget、zip 配布、クロスビルド、ワークフロー内で `jpackage` を直接叩く、`--add-modules` を手で書く、ImageMagick で `.ico` を作り続ける。

## 検証

```
JAVA_HOME=... ./gradlew packageInstaller   → app-image。modules: java.base,java.desktop,java.prefs
"app/build/installer/NeNe Clock/bin/NeNe Clock"   → WSLg で窓が出た（Depth 24・同梱書体・保存済み設定を読めた）
JAVA_HOME=... ./gradlew check              → BUILD SUCCESSFUL
JAVA_HOME=... ./gradlew validateConformance spotlessCheck （文書と workflow を足した後） → 緑
```

**この PR 自身の `Windows installer` workflow が、Windows ランナーで MSI ができることの初めての証明になる。** 成果物 `nene-clock-windows-installer` に MSI と `.sha256` が上がる。

## 残るリスク

- **施主の Windows 実機で入って動くかは未確認。** 成果物の MSI を入れて、起動・設定・終了と、ネイティブの窓でちらつきが起きないかを見てほしい
- 署名が無いので SmartScreen の警告が出る（「詳細情報」→「実行」）。署名は別 Issue
- `version` を入れたので jar 名が `app-0.2.0.jar` になった。`/opt/nene-clock` へ入れ直すと `lib/` の中身が変わる（install script は `installDist` の出力を丸ごと写すので影響なし）
- Windows 側の設定はレジストリに入り、WSL 側と共有されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld7TNxmvu8ekVQyiAJPGXh