### PR TITLE
build(dist): ポータブル zip を MSI の隣に置く。同じ task で app-image → zip → MSI の順に作る (#68)

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -55,6 +55,7 @@ jobs:
           name: nene-clock-windows-installer
           path: |
             app/build/installer/*.msi
+            app/build/installer/*.zip
             app/build/installer/*.sha256
           if-no-files-found: error
 
@@ -65,5 +66,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: >
           gh release create "$GITHUB_REF_NAME"
-          app/build/installer/*.msi app/build/installer/*.sha256
+          app/build/installer/*.msi app/build/installer/*.zip app/build/installer/*.sha256
           --title "NeNe Clock $GITHUB_REF_NAME" --generate-notes

--- a/README.md
+++ b/README.md
@@ -62,11 +62,16 @@ It installs per user (no admin prompt), adds a Start Menu entry and a desktop sh
 re-installing a newer version upgrades in place. The installer is deliberately unsigned, so
 SmartScreen shows "Windows protected your PC" on first launch — choose *More info → Run anyway*.
 
-The installer is built by **one Gradle task** on a Windows runner ([ADR 0013](docs/adr/0013-windows-is-distributed-as-a-jpackage-msi.md)):
+Prefer not to install anything? The same Release carries a **portable zip**: unpack it
+anywhere and run `NeNe Clock.exe` inside the folder. It writes nothing to the registry or
+Start Menu, and shares its settings with the MSI build
+([ADR 0014](docs/adr/0014-a-portable-zip-sits-beside-the-msi.md)).
+
+Both come from **one Gradle task** on a Windows runner ([ADR 0013](docs/adr/0013-windows-is-distributed-as-a-jpackage-msi.md)):
 
 ```bash
-./gradlew packageInstaller      # Windows: app/build/installer/*.msi (+ .sha256)
-                                # elsewhere: an app-image, to prove the wiring
+./gradlew packageInstaller      # app-image → portable zip → (Windows only) MSI, each with .sha256
+                                # elsewhere the app-image and zip still build, to prove the wiring
 ```
 
 `jpackage` bundles a trimmed runtime, the module set comes from `jdeps`, and the `.ico`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,8 @@
 import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
 import java.io.ByteArrayOutputStream
 import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import javax.inject.Inject
 import org.gradle.process.ExecOperations
 
@@ -81,6 +83,18 @@ abstract class PackageInstaller : DefaultTask() {
     @get:OutputDirectory
     abstract val destination: DirectoryProperty
 
+    /** フォルダを zip に畳む。entry 名はフォルダ名から始める（展開すると同じ名前のフォルダが 1 つできる）。 */
+    private fun zipDirectory(directory: File, target: File) {
+        ZipOutputStream(target.outputStream().buffered()).use { zip ->
+            directory.walkTopDown().filter { it.isFile }.sortedBy { it.path }.forEach { file ->
+                val name = directory.name + "/" + file.relativeTo(directory).path.replace(File.separatorChar, '/')
+                zip.putNextEntry(ZipEntry(name))
+                file.inputStream().use { it.copyTo(zip) }
+                zip.closeEntry()
+            }
+        }
+    }
+
     @TaskAction
     fun run() {
         val onWindows = System.getProperty("os.name").startsWith("Windows")
@@ -99,9 +113,11 @@ abstract class PackageInstaller : DefaultTask() {
         out.deleteRecursively()
         out.mkdirs()
         val icon = File(iconDirectory.get().asFile, if (onWindows) "nene-clock.ico" else "nene-clock-256.png")
+        // 1. app-image（exe ＋ 実行環境のフォルダ）。すべての OS で作る。
+        val images = File(out, "image")
         execOperations.exec {
             executable = File(bin, "jpackage").path
-            args("--type", if (onWindows) "msi" else "app-image")
+            args("--type", "app-image")
             args("--name", "NeNe Clock")
             args("--app-version", appVersion.get())
             args("--vendor", "hideyukiMORI")
@@ -111,15 +127,29 @@ abstract class PackageInstaller : DefaultTask() {
             args("--main-class", mainClass.get())
             args("--icon", icon.path)
             args("--add-modules", modules)
-            args("--dest", out.path)
-            if (onWindows) {
+            args("--dest", images.path)
+        }
+        val image = File(images, "NeNe Clock")
+        // 2. ポータブル zip。展開して exe を押すだけで動く。何も入れない（ADR 0014）。
+        val platform = if (onWindows) "windows" else System.getProperty("os.name").lowercase().replace(" ", "-")
+        zipDirectory(image, File(out, "NeNe Clock-${appVersion.get()}-$platform-portable.zip"))
+        // 3. MSI は同じ app-image から作る（Windows だけ）。結線は 1 と同じものを使う。
+        if (onWindows) {
+            execOperations.exec {
+                executable = File(bin, "jpackage").path
+                args("--type", "msi")
+                args("--app-image", image.path)
+                args("--name", "NeNe Clock")
+                args("--app-version", appVersion.get())
+                args("--vendor", "hideyukiMORI")
                 args("--license-file", licenseFile.get().asFile.path)
                 args("--win-menu", "--win-shortcut", "--win-per-user-install")
                 // 入れ直しを「上書き」にする鍵。変えると別製品として並んで入る。
                 args("--win-upgrade-uuid", "ea39da0b-604d-46ab-8ac1-69d155faaec8")
+                args("--dest", out.path)
             }
         }
-        out.listFiles { file -> file.isFile }!!.forEach { file ->
+        out.listFiles { file -> file.isFile && !file.name.endsWith(".sha256") }!!.forEach { file ->
             val digest = MessageDigest.getInstance("SHA-256").digest(file.readBytes())
             val hex = digest.joinToString("") { byte -> "%02x".format(byte) }
             File(out, file.name + ".sha256").writeText("$hex  ${file.name}\n")
@@ -131,7 +161,7 @@ abstract class PackageInstaller : DefaultTask() {
 
 tasks.register<PackageInstaller>("packageInstaller") {
     group = "distribution"
-    description = "インストーラーを作る（Windows は MSI、それ以外は app-image で結線を確かめる）"
+    description = "配布物を作る（app-image → ポータブル zip → Windows なら MSI）"
     dependsOn(tasks.named("installDist"), tasks.named("writeAppIcons"))
     libDirectory.set(layout.buildDirectory.dir("install/app/lib"))
     iconDirectory.set(layout.buildDirectory.dir("icons"))

--- a/docs/adr/0014-a-portable-zip-sits-beside-the-msi.md
+++ b/docs/adr/0014-a-portable-zip-sits-beside-the-msi.md
@@ -1,0 +1,39 @@
+# ADR 0014 — MSI の隣にポータブル zip を置く。1 ファイルの exe は作らない
+
+- 状態: 受理
+- 日付: 2026-09-04
+- Issue: #68
+- 影響する規則: QLT-005 / ARC-012 / ADR 0013
+
+## 文脈
+
+施主要件: インストーラーではなく、入れずに使える形も欲しい（「スタンドアロンの exe」）。
+
+## 決定
+
+1. **`jpackage` の app-image を zip にして配る。** 展開して `NeNe Clock.exe` を押すだけで動き、
+   レジストリにもスタートメニューにも何も書かない
+2. **同じ task（`packageInstaller`）が app-image → zip → MSI の順に作る。** MSI は app-image から作るので、
+   結線（jar・main クラス・アイコン・モジュール集合）は 1 か所で決まる
+3. Release には MSI と zip と SHA-256 が並ぶ。入れたい人は MSI、入れたくない人は zip
+4. **1 ファイルの exe は作らない。** 下の表のとおり、いまの Java に素直な道が無い
+
+## 却下した選択肢
+
+| 選択肢 | 却下の理由 |
+| --- | --- |
+| GraalVM Native Image で 1 ファイルの exe | Swing / AWT の対応は Windows ではまだ実験的。同梱書体・Preferences・Java2D に個別の設定が要り、動くかは試すまで分からない。ツールチェーンの変更でもある。安定してから別 Issue で試す |
+| Launch4j 等で jar を exe に包む | 利用者の PC に Java が入っている前提。要件に反する |
+| 自己展開 zip（7-Zip SFX） | 起動のたびに一時フォルダへ展開する。SmartScreen の印象も悪い |
+| zip を別の Gradle task で作る | 配布物を作る経路が 2 つになる（ARC-012） |
+
+## 強制
+
+- **active**: Linux で `packageInstaller` が zip を作り、中に `bin/NeNe Clock` と `lib/runtime` がある（gate-proofs 第 20 節）
+- **planned**: Windows ランナーで zip と MSI の両方ができる（PR の workflow で走る）
+
+## 結果
+
+- zip は 30 MB 台、展開すると約 90 MB
+- 設定の保存先は MSI 版と同じ（Windows のレジストリ）。zip 版と MSI 版で設定は共有される
+- 「exe 単体」では動かない。隣の `runtime/` と `app/` が要る

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,3 +28,4 @@ ADR は「なぜそう決めたか」「何を却下したか」を書く。
 | [0011](0011-transparency-is-asked-for-not-assumed.md) | 半透明は「頼んで、断られたら諦める」 | 置換（→ 0012） |
 | [0012](0012-transparency-is-dropped-the-artefact-is-not-ours.md) | 透明度をやめる。ちらつきはアプリの外にあった | 受理 |
 | [0013](0013-windows-is-distributed-as-a-jpackage-msi.md) | Windows へは jpackage の MSI で配る。作るのは CI の Windows ランナー | 受理 |
+| [0014](0014-a-portable-zip-sits-beside-the-msi.md) | MSI の隣にポータブル zip を置く。1 ファイルの exe は作らない | 受理 |

--- a/docs/quality/gate-proofs.md
+++ b/docs/quality/gate-proofs.md
@@ -716,9 +716,24 @@ $ xwininfo -id 0x800004 | grep Depth
 目次の先頭 6 バイト・各エントリの幅と高さ・各ポインタの先が PNG 署名であることを見る。
 `tools/place-windows-shortcut.sh` は ImageMagick をやめ、この `.ico` を使う。
 
-### 20.3 まだ証明していないこと
+### 20.3 ポータブル zip は同じ app-image から出る（Issue #68 / ADR 0014）
 
-- Windows ランナーで MSI ができること（PR の workflow で初めて走る）
+```text
+$ ./gradlew packageInstaller
+$ ls app/build/installer/
+NeNe Clock-0.2.0-linux-portable.zip          33 MB
+NeNe Clock-0.2.0-linux-portable.zip.sha256
+image/NeNe Clock/                            ← MSI はここから作る（Windows だけ）
+$ unzip -l "NeNe Clock-0.2.0-linux-portable.zip" | grep -E "bin/NeNe Clock$|lib/runtime/release$"
+    21864  NeNe Clock/bin/NeNe Clock
+       94  NeNe Clock/lib/runtime/release
+```
+
+zip の中は app-image そのもの（93 ファイル・展開で約 90 MB）。起動できることは 20.1 で示した app-image と同一物である。
+
+### 20.4 まだ証明していないこと
+
+- Windows ランナーで MSI と zip ができること（PR の workflow で走る）
 - 施主の Windows 実機で入って起動すること。**ネイティブの窓でちらつきが起きないか**もそこで見る
 - 署名は無い。SmartScreen の警告が出る
 


### PR DESCRIPTION
Closes #68

## 何を

- `packageInstaller` を **app-image → ポータブル zip → MSI（Windows だけ・app-image から作る）** の順に直した。結線は 1 か所
- workflow の成果物と Release に zip を足す
- ADR 0014・README（portable zip の段落）・gate-proofs 20.3

## なぜ

施主要件: 入れずに使える形も欲しい。1 ファイルの exe は Java 21 に素直な道が無い（ADR 0014 の表）。app-image の zip なら、展開して exe を押すだけで動き、何も書き込まない。

## 却下した選択肢

GraalVM Native Image（Swing 対応が Windows で実験的）／Launch4j（利用者に Java が要る）／自己展開 zip／zip を別 task で作る（経路が 2 つになる）。

## 検証

```
./gradlew packageInstaller  → NeNe Clock-0.2.0-linux-portable.zip（33 MB・93 ファイル・bin/NeNe Clock と lib/runtime あり）
./gradlew check             → BUILD SUCCESSFUL
```

この PR の `Windows installer` workflow が、Windows で zip と MSI の両方ができることの証明になる。

## 残るリスク

- `jpackage --type msi --app-image` に渡せるオプションは `--input` 型より少ない。CI で拒否されたら直す
- zip 版は「exe 単体」では動かない（隣の `runtime/` と `app/` が要る）。README に書いた

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld7TNxmvu8ekVQyiAJPGXh