### PR TITLE
build(dist): 配布物のファイル名から空白を外す。GitHub が添付名の空白をドットに変える (#72)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@
 ## ダウンロード
 
 1. [**Releases ページ**](https://github.com/hideyukiMORI/nene-clock/releases/latest) から
-   `NeNe Clock-<version>-windows-portable.zip` を落とす。
+   名前が **`-windows-portable.zip`** で終わるファイルを落とす。
 2. 好きな場所に展開する。デスクトップでも、ドキュメントでも、USB メモリでもよい。`NeNe Clock` というフォルダが 1 つできる。
 3. そのフォルダを開いて **`NeNe Clock.exe`** をダブルクリックする。
 
@@ -44,7 +44,7 @@
 **ダウンロードの検証（任意）。** Release には `.sha256` ファイルも付いている。PowerShell で:
 
 ```powershell
-Get-FileHash '.\NeNe Clock-0.2.0-windows-portable.zip' -Algorithm SHA256
+Get-FileHash (Get-Item '.\NeNe*-windows-portable.zip') -Algorithm SHA256
 ```
 
 出たハッシュを `.sha256` の中身と見比べる。

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ## Download
 
 1. Open the [**Releases page**](https://github.com/hideyukiMORI/nene-clock/releases/latest) and download
-   `NeNe Clock-<version>-windows-portable.zip`.
+   the file that ends in **`-windows-portable.zip`**.
 2. Unzip it anywhere — your Desktop, Documents, a USB stick. You get one folder named `NeNe Clock`.
 3. Open that folder and double-click **`NeNe Clock.exe`**.
 
@@ -44,7 +44,7 @@ runtime is inside the folder. Keep the folder together: the `.exe` needs `runtim
 **Verify the download (optional).** Every Release carries a `.sha256` file. In PowerShell:
 
 ```powershell
-Get-FileHash '.\NeNe Clock-0.2.0-windows-portable.zip' -Algorithm SHA256
+Get-FileHash (Get-Item '.\NeNe*-windows-portable.zip') -Algorithm SHA256
 ```
 
 Compare the hash with the one in the `.sha256` file.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,7 +132,9 @@ abstract class PackageInstaller : DefaultTask() {
         val image = File(images, "NeNe Clock")
         // 2. ポータブル zip。展開して exe を押すだけで動く。何も入れない（ADR 0014）。
         val platform = if (onWindows) "windows" else System.getProperty("os.name").lowercase().replace(" ", "-")
-        zipDirectory(image, File(out, "NeNe Clock-${appVersion.get()}-$platform-portable.zip"))
+        // 🔴 ファイル名に空白を入れない。GitHub は Release の添付名の空白をドットに変える（v0.2.0 で実測・#72）。
+        //    展開後のフォルダ名と exe 名（"NeNe Clock"）は製品名なので、そちらは変えない。
+        zipDirectory(image, File(out, "NeNe-Clock-${appVersion.get()}-$platform-portable.zip"))
         // 3. MSI は同じ app-image から作る（Windows だけ）。結線は 1 と同じものを使う。
         if (onWindows) {
             execOperations.exec {


### PR DESCRIPTION
Closes #72

## 何を

- zip の名前を `NeNe-Clock-<version>-<platform>-portable.zip` にする。展開後のフォルダ名と `NeNe Clock.exe` は製品名なので変えない
- README.md / README.ja.md は名前を決め打ちせず「`-windows-portable.zip` で終わるもの」と書き、ハッシュ検証の例をワイルドカードにする

## なぜ

v0.2.0 の Release で、添付名が `NeNe.Clock-0.2.0-windows-portable.zip` になった（GitHub が空白をドットに変える）。README の記述と実物が食い違っていた。

## 却下した選択肢

- v0.2.0 のタグを付け替える: タグは動かさない。次の版から新しい名前になる
- フォルダ名と exe 名も空白なしにする: 製品名は "NeNe Clock"。利用者が見る名前を配布の都合で変えない

## 検証

```
./gradlew packageInstaller check → 緑。zip 名: NeNe-Clock-0.2.0-linux-portable.zip
```

この PR の Windows installer workflow で、Windows 側の成果物名も確かめる。

## 残るリスク

v0.2.0 の Release の添付名は古いまま（ドット入り）。README は名前を決め打ちしないので矛盾はしない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld7TNxmvu8ekVQyiAJPGXh