### PR TITLE
release: v0.2.1 — 版を上げ、README の版表記と Release の中身（zip と .deb）を合わせる (#76)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   静かなデスクトップ時計。枠もボタンもトレイアイコンも無く、選んだ書体と色で時刻だけがそこにある。<br>
-  Windows · ポータブル · インストール不要 · <a href="README.md">English</a>
+  Windows（ポータブル zip）· Ubuntu（.deb）· インストール不要・Java 不要 · <a href="README.md">English</a>
 </p>
 
 <p align="center">
@@ -21,6 +21,11 @@
 ---
 
 ## ダウンロード
+
+Release には毎回 2 つのファイルが付く。**Windows 向けのポータブル zip** と **Ubuntu 向けの `.deb`**、それぞれに `.sha256`。
+最新は [v0.2.1](https://github.com/hideyukiMORI/nene-clock/releases/latest)。
+
+### Windows
 
 1. [**Releases ページ**](https://github.com/hideyukiMORI/nene-clock/releases/latest) から
    名前が **`-windows-portable.zip`** で終わるファイルを落とす。
@@ -54,7 +59,7 @@ Get-FileHash (Get-Item '.\NeNe*-windows-portable.zip') -Algorithm SHA256
 同じ Release に Ubuntu（と Debian 系・amd64）向けの `.deb` も付いている。
 
 ```bash
-sudo apt install ./nene-clock_0.2.0_amd64.deb   # /opt/nene-clock に入り、メニューに出る
+sudo apt install ./nene-clock_0.2.1_amd64.deb   # /opt/nene-clock に入り、メニューに出る
 "/opt/nene-clock/bin/NeNe Clock"                  # またはアプリメニューの「NeNe Clock」
 sudo apt remove nene-clock                        # 消すとき
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   A quiet desktop clock. No frame, no buttons, no tray icon — just the time, in the typeface and colours you choose.<br>
-  Windows · portable · nothing to install · <a href="README.ja.md">日本語</a>
+  Windows (portable zip) · Ubuntu (.deb) · nothing to install, no Java needed · <a href="README.ja.md">日本語</a>
 </p>
 
 <p align="center">
@@ -21,6 +21,11 @@
 ---
 
 ## Download
+
+Every Release carries two files: a **portable zip for Windows** and a **`.deb` for Ubuntu**, each with a
+`.sha256` next to it. Latest: [v0.2.1](https://github.com/hideyukiMORI/nene-clock/releases/latest).
+
+### Windows
 
 1. Open the [**Releases page**](https://github.com/hideyukiMORI/nene-clock/releases/latest) and download
    the file that ends in **`-windows-portable.zip`**.
@@ -54,7 +59,7 @@ Compare the hash with the one in the `.sha256` file.
 The same Release carries a `.deb` for Ubuntu (and other Debian-based distributions, amd64):
 
 ```bash
-sudo apt install ./nene-clock_0.2.0_amd64.deb   # installs to /opt/nene-clock and adds a menu entry
+sudo apt install ./nene-clock_0.2.1_amd64.deb   # installs to /opt/nene-clock and adds a menu entry
 "/opt/nene-clock/bin/NeNe Clock"                  # or launch "NeNe Clock" from your app menu
 sudo apt remove nene-clock                        # to uninstall
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.configuration-cache=false
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8
 
 # 配布物の版（jpackage の --app-version）。MSI は数字 3 つの形しか受けない。
-version=0.2.0
+version=0.2.1


### PR DESCRIPTION
Closes #76

## 何を

- `version=0.2.1`
- README.md / README.ja.md: 冒頭で「Windows のポータブル zip と Ubuntu の .deb」を示し、ファイル名の例を 0.2.1 に

## 検証

`./gradlew check` 緑。マージ後に `v0.2.1` を打ち、Release workflow が zip と .deb を添付することを確かめる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld7TNxmvu8ekVQyiAJPGXh