### PR TITLE
fix(deb): .desktop に StartupWMClass を入れ、GNOME のドックで製品のアイコンが出るようにする。v0.2.2 (#80)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@
 ## ダウンロード
 
 Release には毎回 2 つのファイルが付く。**Windows 向けのポータブル zip** と **Ubuntu 向けの `.deb`**、それぞれに `.sha256`。
-最新は [v0.2.1](https://github.com/hideyukiMORI/nene-clock/releases/latest)。
+最新は [v0.2.2](https://github.com/hideyukiMORI/nene-clock/releases/latest)。
 
 ### Windows
 
@@ -59,7 +59,7 @@ Get-FileHash (Get-Item '.\NeNe*-windows-portable.zip') -Algorithm SHA256
 同じ Release に Ubuntu（と Debian 系・amd64）向けの `.deb` も付いている。
 
 ```bash
-sudo apt install ./nene-clock_0.2.1_amd64.deb   # /opt/nene-clock に入り、メニューに出る
+sudo apt install ./nene-clock_0.2.2_amd64.deb   # /opt/nene-clock に入り、メニューに出る
 "/opt/nene-clock/bin/NeNe Clock"                  # またはアプリメニューの「NeNe Clock」
 sudo apt remove nene-clock                        # 消すとき
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ## Download
 
 Every Release carries two files: a **portable zip for Windows** and a **`.deb` for Ubuntu**, each with a
-`.sha256` next to it. Latest: [v0.2.1](https://github.com/hideyukiMORI/nene-clock/releases/latest).
+`.sha256` next to it. Latest: [v0.2.2](https://github.com/hideyukiMORI/nene-clock/releases/latest).
 
 ### Windows
 
@@ -59,7 +59,7 @@ Compare the hash with the one in the `.sha256` file.
 The same Release carries a `.deb` for Ubuntu (and other Debian-based distributions, amd64):
 
 ```bash
-sudo apt install ./nene-clock_0.2.1_amd64.deb   # installs to /opt/nene-clock and adds a menu entry
+sudo apt install ./nene-clock_0.2.2_amd64.deb   # installs to /opt/nene-clock and adds a menu entry
 "/opt/nene-clock/bin/NeNe Clock"                  # or launch "NeNe Clock" from your app menu
 sudo apt remove nene-clock                        # to uninstall
 ```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -170,7 +170,8 @@ abstract class PackageInstaller : DefaultTask() {
                 args("--linux-menu-group", "Utility")
                 args("--linux-app-category", "utils")
                 args("--linux-shortcut")
-                // postinst だけ差し替える（app/src/deb/postinst）。最小構成の Linux でメニュー登録が落ちないようにするため。
+                // postinst と .desktop を差し替える（app/src/deb/）。最小構成の Linux でメニュー登録が落ちないようにし、
+                // GNOME が動いている窓とメニュー項目を結びつけられるように StartupWMClass を書くため。
                 args("--resource-dir", debResources.get().asFile.path)
                 args("--dest", out.path)
             }

--- a/app/src/deb/NeNe Clock.desktop
+++ b/app/src/deb/NeNe Clock.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=APPLICATION_NAME
+Comment=APPLICATION_DESCRIPTION
+Exec=APPLICATION_LAUNCHER
+Icon=APPLICATION_ICON
+Terminal=false
+Type=Application
+Categories=DEPLOY_BUNDLE_CATEGORY
+DESKTOP_MIMES
+# 🔴 これが無いと GNOME は動いている窓とこの項目を結びつけられず、ドックの起動中アイコンが既定の絵になる
+#    （2026-09-05・施主の Ubuntu 実機で実測・#80）。Java（AWT/X11）は WM_CLASS にメインクラスの完全修飾名を
+#    「.」→「-」にして使う。メインクラスを改名したらここも変える（gate-proofs 20.6 が突き合わせる）。
+StartupWMClass=io-github-hideyukimori-neneclock-app-NeNeClockApplication

--- a/docs/adr/0015-linux-is-distributed-as-a-deb.md
+++ b/docs/adr/0015-linux-is-distributed-as-a-deb.md
@@ -35,7 +35,7 @@ GitHub で配る Linux のデスクトップアプリの一般形は `.deb`（`s
 - **active**: Linux で `packageInstaller` が `.deb` を作り、WSL の Ubuntu に `dpkg -i` で入って起動し、`apt remove` で消える（gate-proofs 第 20.4 節）
 - **active**: postinst は `app/src/deb/postinst`（jpackage の既定に `mkdir -p /usr/share/desktop-directories` を足したもの）。
   最小構成の Linux で `xdg-desktop-menu` が落ちるのを防ぐ（実測は gate-proofs 20.4）
-- **planned**: Ubuntu の実機（WSL でない）での確認。X11 のライブラリ（`libx11-6` ほか）は依存欄に入るので、デスクトップ環境なら揃っている
+- **active（2026-09-05・施主の Ubuntu 実機）**: 入って起動した。ドックのアイコンは `.desktop` の `StartupWMClass`（`app/src/deb/NeNe Clock.desktop`）で結びつける（#80・gate-proofs 20.6）
 
 ## 結果
 

--- a/docs/quality/gate-proofs.md
+++ b/docs/quality/gate-proofs.md
@@ -761,10 +761,27 @@ jpackage の `--resource-dir` で postinst だけ差し替え（`app/src/deb/pos
 施主が `NeNe Clock-0.2.0.msi`（PR #63 時点の workflow の成果物）を Windows 実機に入れ、**問題なくインストールできた**と確認した。
 アンインストールと上書きインストールは未確認。Release には引き続き zip と `.deb` だけを載せている（#70）。
 
-### 20.6 まだ証明していないこと
+### 20.6 `.deb` は施主の Ubuntu 実機に入った。ドックのアイコンは `StartupWMClass` で結びつける（2026-09-05・#80）
+
+施主が Ubuntu の実機で `sudo apt install ./nene-clock_0.2.1_amd64.deb` を実行し、**入って起動した**。
+ただし**アイコンが既定の絵**だった。jpackage が生成する `.desktop` に `StartupWMClass` が無く、
+GNOME が動いている窓とメニュー項目を結びつけられないため。`--resource-dir` の `NeNe Clock.desktop` で足した。
+
+```text
+$ grep StartupWMClass /opt/nene-clock/lib/nene-clock-NeNe_Clock.desktop
+StartupWMClass=io-github-hideyukimori-neneclock-app-NeNeClockApplication
+$ xprop -id <窓> WM_CLASS
+WM_CLASS(STRING) = "io-github-hideyukimori-neneclock-app-NeNeClockApplication", "io-github-hideyukimori-neneclock-app-NeNeClockApplication"
+```
+
+一致する。Java（AWT/X11）はメインクラスの完全修飾名の「.」を「-」に替えて `WM_CLASS` にする。
+**メインクラスを改名したら `.desktop` の行も変える**（機械では突き合わせていない）。
+同じ `.deb` で 0.2.0 → 0.2.2 の上書きインストールも通った（`Unpacking nene-clock (0.2.2) over (0.2.0)`）。
+
+### 20.7 まだ証明していないこと
 
 - MSI のアンインストールと上書きインストール
-- WSL でない Ubuntu の実機で `.deb` が入ること
+- 施主の Ubuntu 実機で、`StartupWMClass` を入れた版のドックのアイコンが製品のものになること
 - 施主の Windows 実機で入って起動すること。**ネイティブの窓でちらつきが起きないか**もそこで見る
 - 署名は無い。SmartScreen の警告が出る
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.configuration-cache=false
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8
 
 # 配布物の版（jpackage の --app-version）。MSI は数字 3 つの形しか受けない。
-version=0.2.1
+version=0.2.2


### PR DESCRIPTION
Closes #80

## 何を

- `app/src/deb/NeNe Clock.desktop`（jpackage の既定テンプレート ＋ `StartupWMClass=io-github-hideyukimori-neneclock-app-NeNeClockApplication`）を `--resource-dir` で差し替える
- `version=0.2.2`、README の版表記
- gate-proofs 20.6（施主の Ubuntu 実機で入った・WM_CLASS の一致・上書きインストール）、ADR 0015 の該当行を active に

## なぜ

施主の Ubuntu 実機で `.deb` は入り起動もしたが、ドックのアイコンが既定の絵だった。jpackage の `.desktop` に `StartupWMClass` が無く、GNOME が動いている窓とメニュー項目を結びつけられないため。

## 検証

```
./gradlew packageInstaller → nene-clock_0.2.2_amd64.deb
sudo apt install ./nene-clock_0.2.2_amd64.deb → Unpacking (0.2.2) over (0.2.0) / install ok installed
grep StartupWMClass /opt/nene-clock/lib/nene-clock-NeNe_Clock.desktop ↔ xprop WM_CLASS → 一致
./gradlew check → BUILD SUCCESSFUL
```

## 残るリスク

- メインクラスを改名すると `StartupWMClass` が黙ってずれる（機械で突き合わせていない）
- ドックのアイコンが実際に製品のものになるかは施主の実機で v0.2.2 を入れて見る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld7TNxmvu8ekVQyiAJPGXh