### PR TITLE
feat(ui): 設定モーダルのフッターに版とシグネチャを出す (#82)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,14 @@ tasks.withType<CheckForbiddenApis>().configureEach {
         )
 }
 
+// 🔑 版の正本は gradle.properties の version。product.properties へ埋めて、実行時はそこから読む（#82）。
+//    コードに版を書くと 2 か所になり、片方だけ上がる。
+tasks.named<ProcessResources>("processResources") {
+    filesMatching("**/product.properties") {
+        expand("version" to project.version.toString())
+    }
+}
+
 // 🔑 配布物のアイコンは、実装（AppIcon）から書き出す。画像をリポジトリに置かない。
 //    置くと「描いている絵」と「置いた絵」が別々に存在し、片方だけ古くなる。
 tasks.register<JavaExec>("writeAppIcons") {

--- a/app/src/main/java/io/github/hideyukimori/neneclock/app/NeNeClockApplication.java
+++ b/app/src/main/java/io/github/hideyukimori/neneclock/app/NeNeClockApplication.java
@@ -59,7 +59,7 @@ public final class NeNeClockApplication {
         SettingsHandler settings = SettingsHandler.restoredFrom(settingsStore);
         ClockFaceQuery clockFace = new ClockFaceQuery(SystemWallClockAdapter.system());
 
-        ClockScreen screen = new ClockScreen(new TypefaceFontLoader(typefaceBinaries));
+        ClockScreen screen = new ClockScreen(new TypefaceFontLoader(typefaceBinaries), ProductIdentityFile.read());
         ClockTicker ticker = new ClockTicker(() -> screen.renderFace(clockFace.currentFace(settings.current())));
 
         screen.onSettingsRequested(requested -> {

--- a/app/src/main/java/io/github/hideyukimori/neneclock/app/ProductIdentityFile.java
+++ b/app/src/main/java/io/github/hideyukimori/neneclock/app/ProductIdentityFile.java
@@ -1,0 +1,38 @@
+package io.github.hideyukimori.neneclock.app;
+
+import io.github.hideyukimori.neneclock.domain.ProductIdentity;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+/**
+ * 同梱の {@code product.properties} から製品の名乗りを読む。
+ *
+ * <p>版はビルドが埋める（{@code gradle.properties} → {@code processResources}）。コードに版を書かないのは、
+ * 2 か所に同じ数字があると片方だけ上がるからである。読めないのはビルドの欠陥なので、ここでは例外にする。
+ */
+final class ProductIdentityFile {
+
+    private static final String RESOURCE = "product.properties";
+
+    private ProductIdentityFile() {}
+
+    static ProductIdentity read() {
+        try (InputStream stream = ProductIdentityFile.class.getResourceAsStream(RESOURCE)) {
+            if (stream == null) {
+                throw new IllegalStateException("product.properties is missing from the build");
+            }
+            Properties properties = new Properties();
+            try (Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+                properties.load(reader);
+            }
+            return new ProductIdentity(properties.getProperty("version", ""), properties.getProperty("author", ""));
+        } catch (IOException failure) {
+            throw new UncheckedIOException(failure);
+        }
+    }
+}

--- a/app/src/main/resources/io/github/hideyukimori/neneclock/app/product.properties
+++ b/app/src/main/resources/io/github/hideyukimori/neneclock/app/product.properties
@@ -1,0 +1,3 @@
+# 版の正本は gradle.properties の version。processResources がここへ埋める（app/build.gradle.kts）。
+version=${version}
+author=hideyukiMORI

--- a/app/src/test/java/io/github/hideyukimori/neneclock/app/ProductIdentityFileTest.java
+++ b/app/src/test/java/io/github/hideyukimori/neneclock/app/ProductIdentityFileTest.java
@@ -1,0 +1,18 @@
+package io.github.hideyukimori.neneclock.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.hideyukimori.neneclock.domain.ProductIdentity;
+import org.junit.jupiter.api.Test;
+
+class ProductIdentityFileTest {
+
+    @Test
+    void theBuildFillsInARealVersionAndAnAuthor() {
+        ProductIdentity identity = ProductIdentityFile.read();
+
+        assertThat(identity.version()).matches("\\d+\\.\\d+\\.\\d+");
+        assertThat(identity.version()).doesNotContain("${");
+        assertThat(identity.author()).isEqualTo("hideyukiMORI");
+    }
+}

--- a/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/ProductIdentity.java
+++ b/core/domain/src/main/java/io/github/hideyukimori/neneclock/domain/ProductIdentity.java
@@ -1,0 +1,24 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import java.util.Objects;
+
+/**
+ * 製品の名乗り（版と作者）。設定モーダルのフッターに出す。
+ *
+ * <p>版の正本はビルド（{@code gradle.properties} の {@code version}）にあり、ここは運ばれてきた値を
+ * 持つだけである。検証済みの値の組なので {@code record} でよい（JAV-007）。
+ * 年は持たない。現在時刻を読めない（ARC-007）ので、著作権表示の年を自動で作る経路が無い。
+ *
+ * @param version 版。空でない
+ * @param author 作者。空でない
+ */
+public record ProductIdentity(String version, String author) {
+
+    public ProductIdentity {
+        Objects.requireNonNull(version, "version");
+        Objects.requireNonNull(author, "author");
+        if (version.isBlank() || author.isBlank()) {
+            throw new IllegalArgumentException("version and author must not be blank");
+        }
+    }
+}

--- a/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/ProductIdentityTest.java
+++ b/core/domain/src/test/java/io/github/hideyukimori/neneclock/domain/ProductIdentityTest.java
@@ -1,0 +1,27 @@
+package io.github.hideyukimori.neneclock.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.Test;
+
+class ProductIdentityTest {
+
+    @Test
+    void carriesTheVersionAndAuthorItWasGiven() {
+        ProductIdentity identity = new ProductIdentity("0.2.2", "hideyukiMORI");
+
+        assertThat(identity.version()).isEqualTo("0.2.2");
+        assertThat(identity.author()).isEqualTo("hideyukiMORI");
+    }
+
+    @Test
+    void refusesABlankVersion() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new ProductIdentity(" ", "hideyukiMORI"));
+    }
+
+    @Test
+    void refusesABlankAuthor() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new ProductIdentity("0.2.2", ""));
+    }
+}

--- a/docs/quality/gate-proofs.md
+++ b/docs/quality/gate-proofs.md
@@ -778,7 +778,13 @@ WM_CLASS(STRING) = "io-github-hideyukimori-neneclock-app-NeNeClockApplication", 
 **メインクラスを改名したら `.desktop` の行も変える**（機械では突き合わせていない）。
 同じ `.deb` で 0.2.0 → 0.2.2 の上書きインストールも通った（`Unpacking nene-clock (0.2.2) over (0.2.0)`）。
 
-### 20.7 まだ証明していないこと
+### 20.7 版とシグネチャがフッターに出る（Issue #82・2026-09-05）
+
+`./gradlew run`（作業木・`version=0.2.2`）で設定モーダルを開き、フッター右端に
+`NeNe Clock 0.2.2 · hideyukiMORI` が薄い文字で出ることを目視した。版は `product.properties` 経由で
+`gradle.properties` から来ており、コードには書いていない（`ProductIdentityFileTest` が `${` の残留を拒否する）。
+
+### 20.8 まだ証明していないこと
 
 - MSI のアンインストールと上書きインストール
 - 施主の Ubuntu 実機で、`StartupWMClass` を入れた版のドックのアイコンが製品のものになること

--- a/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/ClockScreen.java
+++ b/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/ClockScreen.java
@@ -5,6 +5,7 @@ import io.github.hideyukimori.neneclock.application.DateLine;
 import io.github.hideyukimori.neneclock.application.SettingsIntentSink;
 import io.github.hideyukimori.neneclock.application.SettingsSaveOutcome;
 import io.github.hideyukimori.neneclock.domain.Language;
+import io.github.hideyukimori.neneclock.domain.ProductIdentity;
 import io.github.hideyukimori.neneclock.domain.RgbColor;
 import io.github.hideyukimori.neneclock.domain.Typeface;
 import io.github.hideyukimori.neneclock.domain.UserSettings;
@@ -37,9 +38,10 @@ public final class ClockScreen {
     private Runnable quit = () -> {};
     private UserSettings shown = UserSettings.defaults();
 
-    /** 同梱書体の読み手だけを受け取り、画面を組み立てる。 */
-    public ClockScreen(TypefaceFontLoader typefaces) {
+    /** 同梱書体の読み手と製品の名乗りを受け取り、画面を組み立てる。 */
+    public ClockScreen(TypefaceFontLoader typefaces, ProductIdentity identity) {
         Objects.requireNonNull(typefaces, "typefaces");
+        Objects.requireNonNull(identity, "identity");
         // 🔑 UI 書体はここで 1 度だけ組み立てる。Font.createFont は重く、deriveFont は軽い。
         for (Language language : Language.values()) {
             interfaceFonts.put(language, typefaces.load(language.typeface(), INTERFACE_POINTS));
@@ -50,7 +52,8 @@ public final class ClockScreen {
         this.form = new SettingsFormPanel(typefaces);
         this.typefacePicker = new TypefacePickerPanel(typefaces);
         this.colourPicker = new ColourPickerPanel(typefaces);
-        this.dialog = new SettingsDialog(window.owner(), new SettingsPanels(form, typefacePicker, colourPicker));
+        this.dialog =
+                new SettingsDialog(window.owner(), new SettingsPanels(form, typefacePicker, colourPicker), identity);
         connect();
     }
 

--- a/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/SettingsDialog.java
+++ b/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/SettingsDialog.java
@@ -2,11 +2,13 @@ package io.github.hideyukimori.neneclock.ui.swing;
 
 import io.github.hideyukimori.neneclock.application.SettingsSaveFailure;
 import io.github.hideyukimori.neneclock.application.SettingsSaveOutcome;
+import io.github.hideyukimori.neneclock.domain.ProductIdentity;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.geom.RoundRectangle2D;
+import java.util.Locale;
 import java.util.Objects;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -43,6 +45,8 @@ public final class SettingsDialog {
     private final JPanel footer = new JPanel(new BorderLayout());
     private final JLabel title = TextRendering.label("");
     private final JLabel status = TextRendering.label("");
+    private final JLabel signature = TextRendering.label("");
+    private final ProductIdentity identity;
     private final IconButton back = new IconButton(ChromeIcon.BACK);
     private final IconButton close = new IconButton(ChromeIcon.CLOSE);
 
@@ -55,8 +59,9 @@ public final class SettingsDialog {
     private @Nullable UiTheme theme;
 
     /** 3 つの画面を束ねて 1 つのモーダルにする。 */
-    public SettingsDialog(Frame owner, SettingsPanels panels) {
+    public SettingsDialog(Frame owner, SettingsPanels panels, ProductIdentity identity) {
         this.dialog = new JDialog(Objects.requireNonNull(owner, "owner"));
+        this.identity = Objects.requireNonNull(identity, "identity");
         this.form = panels.form();
         this.typefaces = panels.typefaces();
         this.colours = panels.colours();
@@ -113,6 +118,7 @@ public final class SettingsDialog {
         Palette palette = shownTheme.palette();
         renderTitle(shownTheme);
         renderStatusText(shownTheme);
+        renderSignature(shownTheme);
         dialog.getContentPane().setBackground(palette.surface());
         header.setBackground(palette.surface());
         footer.setBackground(palette.surface());
@@ -127,6 +133,14 @@ public final class SettingsDialog {
                 BorderFactory.createEmptyBorder(0, SIDE, 0, SIDE)));
         back.renderColours(shownTheme);
         close.renderColours(shownTheme);
+    }
+
+    /** 版と作者。フッターの右端に、状態行より薄く出す。 */
+    private void renderSignature(UiTheme shownTheme) {
+        signature.setText(
+                String.format(Locale.ROOT, shownTheme.text(UiText.SIGNATURE), identity.version(), identity.author()));
+        signature.setFont(shownTheme.font(STATUS_POINTS));
+        signature.setForeground(shownTheme.palette().textFaint());
     }
 
     /** 状態行を、いまの言語で書き直す。 */
@@ -186,6 +200,7 @@ public final class SettingsDialog {
         header.add(close.component(), BorderLayout.EAST);
         footer.setPreferredSize(new Dimension(0, FOOTER_HEIGHT));
         footer.add(status, BorderLayout.WEST);
+        footer.add(signature, BorderLayout.EAST);
         body.add(form.component(), "form");
         body.add(typefaces.component(), "typeface");
         body.add(colours.component(), "colour");

--- a/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/UiText.java
+++ b/ui/swing/src/main/java/io/github/hideyukimori/neneclock/ui/swing/UiText.java
@@ -62,7 +62,9 @@ public enum UiText {
     /** 保存できなかったときの状態行。 */
     NOT_SAVED(
             "保存できませんでした。いまは反映されていますが、再起動すると元に戻ります",
-            "Could not save. The change applies now but will be lost on restart");
+            "Could not save. The change applies now but will be lost on restart"),
+    /** フッター右端の名乗り。書式引数は版と作者の 2 つ。 */
+    SIGNATURE("NeNe Clock %s · %s", "NeNe Clock %s · %s");
 
     private final String japanese;
     private final String english;


### PR DESCRIPTION
Closes #82

## 何を

- 設定モーダルのフッター右端に `NeNe Clock 0.2.2 · hideyukiMORI`（薄い小さな文字）
- 版の正本は `gradle.properties` の `version`。`processResources` が `product.properties` に埋め、`:app` の `ProductIdentityFile` が読み、`ProductIdentity`（domain の record）として `ClockScreen` → `SettingsDialog` に渡す。作者名も同じファイル
- 文言は `UiText.SIGNATURE`（書式 `NeNe Clock %s · %s`・両言語同じ）。年は持たない（現在時刻を読めない・ARC-007）

## 却下した選択肢

- jar の manifest（`Implementation-Version`）から読む: `./gradlew run` ではクラスディレクトリから動くので manifest が無く、「dev」になる。resource なら両方で同じ版
- コードに版を書く: 2 か所になり片方だけ上がる
- 時計本体に出す: 時計は時刻だけ（FR-047）

## 検証

```
./gradlew check → BUILD SUCCESSFUL（domain の分岐カバレッジは ProductIdentityTest で 90% を維持。閾値は触っていない）
./gradlew run → モーダルのフッター右端に NeNe Clock 0.2.2 · hideyukiMORI（gate-proofs 20.7）
```

## 残るリスク

- README のスクリーンショット（settings.png 等）はフッターに版が無い古い絵。次に UI を撮り直すときに更新する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld7TNxmvu8ekVQyiAJPGXh