### PR TITLE
fix(deb): .deb のアイコンに --icon を渡す。jpackage の既定（duke）が出ていた。v0.2.3 (#84)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@
 ## ダウンロード
 
 Release には毎回 2 つのファイルが付く。**Windows 向けのポータブル zip** と **Ubuntu 向けの `.deb`**、それぞれに `.sha256`。
-最新は [v0.2.2](https://github.com/hideyukiMORI/nene-clock/releases/latest)。
+最新は [v0.2.3](https://github.com/hideyukiMORI/nene-clock/releases/latest)。
 
 ### Windows
 
@@ -59,7 +59,7 @@ Get-FileHash (Get-Item '.\NeNe*-windows-portable.zip') -Algorithm SHA256
 同じ Release に Ubuntu（と Debian 系・amd64）向けの `.deb` も付いている。
 
 ```bash
-sudo apt install ./nene-clock_0.2.2_amd64.deb   # /opt/nene-clock に入り、メニューに出る
+sudo apt install ./nene-clock_0.2.3_amd64.deb   # /opt/nene-clock に入り、メニューに出る
 "/opt/nene-clock/bin/NeNe Clock"                  # またはアプリメニューの「NeNe Clock」
 sudo apt remove nene-clock                        # 消すとき
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ## Download
 
 Every Release carries two files: a **portable zip for Windows** and a **`.deb` for Ubuntu**, each with a
-`.sha256` next to it. Latest: [v0.2.2](https://github.com/hideyukiMORI/nene-clock/releases/latest).
+`.sha256` next to it. Latest: [v0.2.3](https://github.com/hideyukiMORI/nene-clock/releases/latest).
 
 ### Windows
 
@@ -59,7 +59,7 @@ Compare the hash with the one in the `.sha256` file.
 The same Release carries a `.deb` for Ubuntu (and other Debian-based distributions, amd64):
 
 ```bash
-sudo apt install ./nene-clock_0.2.2_amd64.deb   # installs to /opt/nene-clock and adds a menu entry
+sudo apt install ./nene-clock_0.2.3_amd64.deb   # installs to /opt/nene-clock and adds a menu entry
 "/opt/nene-clock/bin/NeNe Clock"                  # or launch "NeNe Clock" from your app menu
 sudo apt remove nene-clock                        # to uninstall
 ```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -178,11 +178,35 @@ abstract class PackageInstaller : DefaultTask() {
                 args("--linux-menu-group", "Utility")
                 args("--linux-app-category", "utils")
                 args("--linux-shortcut")
+                // 🔴 --app-image から作るときも --icon を渡す。渡さないと jpackage は app-image の中の
+                //    アイコンを流用せず、**自前の既定（duke）**をデスクトップ項目に使う。
+                //    施主の Ubuntu 実機で「アイコンが既定のまま」になっていた原因がこれだった（#84）。
+                args("--icon", File(iconDirectory.get().asFile, "nene-clock-256.png").path)
                 // postinst と .desktop を差し替える（app/src/deb/）。最小構成の Linux でメニュー登録が落ちないようにし、
                 // GNOME が動いている窓とメニュー項目を結びつけられるように StartupWMClass を書くため。
                 args("--resource-dir", debResources.get().asFile.path)
                 args("--dest", out.path)
             }
+        }
+        // 🔑 できた .deb を開いて、デスクトップ項目が指すアイコンが**我々の絵**であることを確かめる。
+        //    jpackage は --icon を渡さないと自前の既定（duke）を黙って使う。それに 2 版ぶん気づけなかった（#84）。
+        //    「渡したつもり」を人の記憶に頼らせない。
+        File(out, "").listFiles { file -> file.name.endsWith(".deb") }?.forEach { deb ->
+            val opened = File(temporaryDir, "deb-check").also { it.deleteRecursively() }
+            execOperations.exec {
+                executable = "dpkg-deb"
+                args("-x", deb.path, opened.path)
+            }
+            val entry = opened.walkTopDown().first { it.name.endsWith(".desktop") }
+            val iconPath = entry.readLines().first { it.startsWith("Icon=") }.removePrefix("Icon=")
+            val packaged = File(opened, iconPath.removePrefix("/"))
+            val wanted = File(iconDirectory.get().asFile, "nene-clock-256.png")
+            if (!packaged.exists() || !packaged.readBytes().contentEquals(wanted.readBytes())) {
+                throw GradleException(
+                    "the .deb desktop entry points at an icon that is not ours: $iconPath " +
+                        "(jpackage falls back to its own default when --icon is missing)")
+            }
+            opened.deleteRecursively()
         }
         out.listFiles { file -> file.isFile && !file.name.endsWith(".sha256") }!!.forEach { file ->
             val digest = MessageDigest.getInstance("SHA-256").digest(file.readBytes())

--- a/app/src/deb/NeNe Clock.desktop
+++ b/app/src/deb/NeNe Clock.desktop
@@ -7,7 +7,9 @@ Terminal=false
 Type=Application
 Categories=DEPLOY_BUNDLE_CATEGORY
 DESKTOP_MIMES
-# 🔴 これが無いと GNOME は動いている窓とこの項目を結びつけられず、ドックの起動中アイコンが既定の絵になる
-#    （2026-09-05・施主の Ubuntu 実機で実測・#80）。Java（AWT/X11）は WM_CLASS にメインクラスの完全修飾名を
-#    「.」→「-」にして使う。メインクラスを改名したらここも変える（gate-proofs 20.6 が突き合わせる）。
+# GNOME が動いている窓とこの項目を結びつけるための行。Java（AWT/X11）は WM_CLASS に
+# メインクラスの完全修飾名を「.」→「-」にして使う。メインクラスを改名したらここも変える。
+# ⚠️ 2026-09-05 に「アイコンが既定の絵になる」原因をこの行の不在だと書いたが、**それは誤診だった**。
+#    本当の原因は .deb を作るとき --icon を渡していなかったこと（#84）。この行は窓の結びつけには要るが、
+#    アイコンの絵を決めてはいない。記録は gate-proofs 20.6。
 StartupWMClass=io-github-hideyukimori-neneclock-app-NeNeClockApplication

--- a/docs/adr/0015-linux-is-distributed-as-a-deb.md
+++ b/docs/adr/0015-linux-is-distributed-as-a-deb.md
@@ -35,7 +35,12 @@ GitHub で配る Linux のデスクトップアプリの一般形は `.deb`（`s
 - **active**: Linux で `packageInstaller` が `.deb` を作り、WSL の Ubuntu に `dpkg -i` で入って起動し、`apt remove` で消える（gate-proofs 第 20.4 節）
 - **active**: postinst は `app/src/deb/postinst`（jpackage の既定に `mkdir -p /usr/share/desktop-directories` を足したもの）。
   最小構成の Linux で `xdg-desktop-menu` が落ちるのを防ぐ（実測は gate-proofs 20.4）
-- **active（2026-09-05・施主の Ubuntu 実機）**: 入って起動した。ドックのアイコンは `.desktop` の `StartupWMClass`（`app/src/deb/NeNe Clock.desktop`）で結びつける（#80・gate-proofs 20.6）
+- **active（2026-09-05・施主の Ubuntu 実機）**: 入って起動した
+- **active**: デスクトップ項目のアイコンは `--icon` で明示的に渡す。`--app-image` から作るとき jpackage は
+  app-image の中のアイコンを流用せず、**自前の既定を黙って使う**（#84 で 2 版ぶん見逃した）。
+  `packageInstaller` が、できた `.deb` を開いてアイコンが `AppIcon` の出力と一致することを確かめる（gate-proofs 20.8）
+- **active**: `.desktop` の `StartupWMClass` は窓とメニュー項目の結びつけに要る（`app/src/deb/NeNe Clock.desktop`）。
+  ⚠️ ただしアイコンの絵は決めない（#80 でそう書いたのは誤診）
 
 ## 結果
 

--- a/docs/quality/gate-proofs.md
+++ b/docs/quality/gate-proofs.md
@@ -764,8 +764,8 @@ jpackage の `--resource-dir` で postinst だけ差し替え（`app/src/deb/pos
 ### 20.6 `.deb` は施主の Ubuntu 実機に入った。ドックのアイコンは `StartupWMClass` で結びつける（2026-09-05・#80）
 
 施主が Ubuntu の実機で `sudo apt install ./nene-clock_0.2.1_amd64.deb` を実行し、**入って起動した**。
-ただし**アイコンが既定の絵**だった。jpackage が生成する `.desktop` に `StartupWMClass` が無く、
-GNOME が動いている窓とメニュー項目を結びつけられないため。`--resource-dir` の `NeNe Clock.desktop` で足した。
+ただし**アイコンが既定の絵**だった。このとき原因を `StartupWMClass` の不在だと書いたが、
+🔴 **それは誤診である**（真の原因は 20.8。この節の以下は `StartupWMClass` 自体の記録として残す）。
 
 ```text
 $ grep StartupWMClass /opt/nene-clock/lib/nene-clock-NeNe_Clock.desktop
@@ -784,7 +784,59 @@ WM_CLASS(STRING) = "io-github-hideyukimori-neneclock-app-NeNeClockApplication", 
 `NeNe Clock 0.2.2 · hideyukiMORI` が薄い文字で出ることを目視した。版は `product.properties` 経由で
 `gradle.properties` から来ており、コードには書いていない（`ProductIdentityFileTest` が `${` の残留を拒否する）。
 
-### 20.8 まだ証明していないこと
+## 20.8 🔴 アイコンが既定のままだった本当の理由（Issue #84・2026-09-05）
+
+### 20.8.1 誤診をもう一度した
+
+施主の報告は「アイコンが既定のまま」。私は**アイコンのファイルを一度も見ないまま**、
+「窓とメニュー項目が結びついていないからだ」と決めて `StartupWMClass` を足した（#80・v0.2.2）。
+施主が入れ直し、ログアウトまでしても直らなかった。
+
+2 回目に**見るほうを先にした**。`.desktop` が指す PNG を突き合わせただけで 1 分で決着した。
+
+```text
+$ grep ^Icon= /opt/nene-clock/lib/nene-clock-NeNe_Clock.desktop
+Icon=/opt/nene-clock/lib/NeNe_Clock.png
+$ identify -format '%wx%h' その PNG        →  32x32          ← 我々の絵は 256x256
+$ sha256sum その PNG
+8b2491d0b5cbc67075dcae4d29c8a92b9ab813d9eca05a2f16ee3b3efb970e65
+$ sha256sum <jdk.jpackage.jmod>/resources/JavaApp.png
+8b2491d0b5cbc67075dcae4d29c8a92b9ab813d9eca05a2f16ee3b3efb970e65   ← バイト単位で同一
+```
+
+**表示されていたのは jpackage の既定アイコンそのものだった。**
+`.deb` を `--app-image` から作るとき、jpackage は app-image の中のアイコンを**流用しない**。
+デスクトップ統合用に `--icon` を別途要求し、無ければ自前の既定を黙って使う。
+
+⚠️ ここでも [ADR 0012](../adr/0012-transparency-is-dropped-the-artefact-is-not-ours.md) の教訓が繰り返された。
+**「直して直らなかったら、見立てを疑う番である。」** 直し方（ログアウト・入れ直し）を変える番ではなかった。
+`StartupWMClass` は窓の結びつけには要るので残したが、**症状の原因ではなかった**。
+
+### 20.8.2 直したあと
+
+```text
+$ sha256sum /opt/nene-clock/lib/NeNe_Clock.png      ← .deb v0.2.3 を入れたあと
+4103f880d9ad2b31d501b607f567f5627382af54dc79a869c705e42cb150e635   256x256
+$ sha256sum app/build/icons/nene-clock-256.png
+4103f880d9ad2b31d501b607f567f5627382af54dc79a869c705e42cb150e635   ← AppIcon の出力と一致
+```
+
+### 20.8.3 機械に守らせた（negative proof つき）
+
+「`--icon` を渡し忘れる」を人の記憶に頼らせない。`packageInstaller` は作った `.deb` を `dpkg-deb -x` で開き、
+デスクトップ項目が指すアイコンが `AppIcon` の 256px 出力と**バイト単位で一致**しなければビルドを落とす。
+
+わざと `--icon` を外して、落ちることと**落ちた理由**を確かめた:
+
+```text
+> the .deb desktop entry points at an icon that is not ours: /opt/nene-clock/lib/NeNe_Clock.png
+  (jpackage falls back to its own default when --icon is missing)
+BUILD FAILED
+```
+
+戻すと通る。
+
+### 20.9 まだ証明していないこと
 
 - MSI のアンインストールと上書きインストール
 - 施主の Ubuntu 実機で、`StartupWMClass` を入れた版のドックのアイコンが製品のものになること

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.configuration-cache=false
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8
 
 # 配布物の版（jpackage の --app-version）。MSI は数字 3 つの形しか受けない。
-version=0.2.2
+version=0.2.3


### PR DESCRIPTION
Closes #84

## 何を

- `.deb` を作る呼び出しに **`--icon`** を渡す（`nene-clock-256.png`）
- できた `.deb` を `dpkg-deb -x` で開き、デスクトップ項目が指すアイコンが `AppIcon` の 256px 出力と**バイト単位で一致**しなければビルドを落とす検査を足す
- `version=0.2.3`、README の版表記
- **#80 の誤診の訂正**（`.desktop` のコメント / gate-proofs 20.6 / ADR 0015）と、今回の実測（gate-proofs 20.8）

## 🔴 なぜ 2 版かかったか

施主の報告は「アイコンが既定のまま」。1 回目は**アイコンのファイルを一度も見ないまま**「窓とメニュー項目が結びついていない」と決めて `StartupWMClass` を足した（#80・v0.2.2）。施主が入れ直してログアウトしても直らなかった。

2 回目に見るほうを先にしたら 1 分で決着した。

```
Icon= が指す PNG   sha256 8b2491d0…  32x32
jpackage の既定    sha256 8b2491d0…  ← バイト単位で同一
```

出ていたのは jpackage の既定アイコンそのもの。`--app-image` から `.deb` を作るとき、jpackage は app-image の中のアイコンを流用せず、`--icon` が無ければ自前の既定を黙って使う。

⚠️ ADR 0012 の教訓の再演である。**直して直らなかったら、見立てを疑う番。** 直し方（ログアウト・入れ直し）を変える番ではなかった。`StartupWMClass` は窓の結びつけには要るので残すが、症状の原因ではなかった。

## 検証

```
修正後: Icon= が指す PNG sha256 4103f880… 256x256 ＝ AppIcon の出力と一致（jpackage の既定とは不一致）
negative proof: --icon を外すと
  > the .deb desktop entry points at an icon that is not ours: … (jpackage falls back to its own default when --icon is missing)
  BUILD FAILED
  戻すと通る
./gradlew check → BUILD SUCCESSFUL
```

## 残るリスク

- 施主の Ubuntu 実機での見た目は v0.2.3 を入れて確認してもらう。**入れ直したあとログアウトが要る場合がある**（GNOME がアイコンを覚えているため）
- 同じ「既定に黙って落ちる」経路が Windows 側（MSI）にもあり得るが、そちらは `--icon` を渡している

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld7TNxmvu8ekVQyiAJPGXh