### PR TITLE
release: 検証済みの MSI も Release に載せる。名前から空白を外す。v0.2.4 (#86)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,9 @@ jobs:
             app/build/installer/*.sha256
           if-no-files-found: error
 
-  # 配るのは Windows のポータブル zip と Ubuntu の .deb（施主決定 2026-09-04 / 09-05）。
-  # MSI は作るが、検証するまで Release に載せない。run の成果物には残る。
+  # 配るのは Windows のポータブル zip と MSI、Ubuntu の .deb。
+  # MSI は #70 の時点で未検証だったので外していたが、2026-09-05 に施主の Windows 実機で入ることを
+  # 確かめたので載せる（gate-proofs 20.5 / ADR 0013 / #86）。
   release:
     name: release
     if: startsWith(github.ref, 'refs/tags/v')
@@ -106,5 +107,6 @@ jobs:
         run: >
           gh release create "$GITHUB_REF_NAME"
           dist/nene-clock-windows/*-windows-portable.zip dist/nene-clock-windows/*-windows-portable.zip.sha256
+          dist/nene-clock-windows/*.msi dist/nene-clock-windows/*.msi.sha256
           dist/nene-clock-linux/*.deb dist/nene-clock-linux/*.deb.sha256
           --repo "$GITHUB_REPOSITORY" --title "NeNe Clock $GITHUB_REF_NAME" --generate-notes

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,8 +22,9 @@
 
 ## ダウンロード
 
-Release には毎回 2 つのファイルが付く。**Windows 向けのポータブル zip** と **Ubuntu 向けの `.deb`**、それぞれに `.sha256`。
-最新は [v0.2.3](https://github.com/hideyukiMORI/nene-clock/releases/latest)。
+Release には毎回 3 つのファイルが付く。Windows 向けの**ポータブル zip** と**インストーラ（`.msi`）**、
+Ubuntu 向けの **`.deb`**。それぞれに `.sha256` が付く。
+最新は [v0.2.4](https://github.com/hideyukiMORI/nene-clock/releases/latest)。
 
 ### Windows
 
@@ -35,6 +36,10 @@ Release には毎回 2 つのファイルが付く。**Windows 向けのポー�
 これだけ。インストーラーも管理者権限も要らず、**Java も要らない**。刻んだ実行環境がフォルダの中に入っている。
 フォルダはばらさないこと。`.exe` は隣の `runtime/` と `app/` を使う。
 
+**ちゃんと入れたいなら** `.msi` を落としてダブルクリックする。ユーザー単位で入るので管理者権限は要らない。
+スタートメニューとデスクトップにショートカットが付き、新しい版を入れると上書きになり、
+「設定 → アプリ」から消せる。中身も設定も zip 版と同じで、Windows に管理させるかどうかの違いだけである。
+
 | | |
 | --- | --- |
 | 動く環境 | Windows 10 / 11（64 ビット）。Ubuntu は[下記](#ubuntu) |
@@ -43,7 +48,7 @@ Release には毎回 2 つのファイルが付く。**Windows 向けのポー�
 | 残すもの | 設定だけ。`HKEY_CURRENT_USER\Software\JavaSoft\Prefs\io\github\hideyukimori\neneclock` |
 | 消し方 | フォルダを消す（まっさらにしたければ上のレジストリキーも） |
 
-**初回起動時の SmartScreen。** zip はコード署名していないので、最初の 1 回だけ
+**初回起動時の SmartScreen。** どちらもコード署名していないので、最初の 1 回だけ
 「Windows によって PC が保護されました」と出る。**「詳細情報」→「実行」**で通る。次からは出ない。
 
 **ダウンロードの検証（任意）。** Release には `.sha256` ファイルも付いている。PowerShell で:
@@ -59,7 +64,7 @@ Get-FileHash (Get-Item '.\NeNe*-windows-portable.zip') -Algorithm SHA256
 同じ Release に Ubuntu（と Debian 系・amd64）向けの `.deb` も付いている。
 
 ```bash
-sudo apt install ./nene-clock_0.2.3_amd64.deb   # /opt/nene-clock に入り、メニューに出る
+sudo apt install ./nene-clock_0.2.4_amd64.deb   # /opt/nene-clock に入り、メニューに出る
 "/opt/nene-clock/bin/NeNe Clock"                  # またはアプリメニューの「NeNe Clock」
 sudo apt remove nene-clock                        # 消すとき
 ```
@@ -207,8 +212,7 @@ Windows では `.\gradlew.bat` に同じ task 名を渡す。WSLg なら `DISPLA
 
 1. `jpackage` が **app-image** を作る。起動ファイル・jar・`jdeps` が必要と言ったモジュールだけに刻んだ実行環境。
 2. そのフォルダを zip にしたものが**ポータブル zip**。Release に付くのはこれ。
-3. Windows では同じ app-image から **MSI** も作る。タグを打つたびに作られ workflow の成果物には残るが、
-   検証するまで公開しない。
+3. Windows では同じ app-image から **MSI** も作る。
 4. Linux では同じ app-image から **`.deb`** を作る（[ADR 0015](docs/adr/0015-linux-is-distributed-as-a-deb.md)）。
 
 `jpackage` は動いている OS 向けにしか作れないので、GitHub Actions の *Release* workflow が

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@
 
 ## Download
 
-Every Release carries two files: a **portable zip for Windows** and a **`.deb` for Ubuntu**, each with a
-`.sha256` next to it. Latest: [v0.2.3](https://github.com/hideyukiMORI/nene-clock/releases/latest).
+Every Release carries three downloads, each with a `.sha256` next to it: a **portable zip** and an
+**installer (`.msi`)** for Windows, and a **`.deb`** for Ubuntu.
+Latest: [v0.2.4](https://github.com/hideyukiMORI/nene-clock/releases/latest).
 
 ### Windows
 
@@ -35,6 +36,10 @@ Every Release carries two files: a **portable zip for Windows** and a **`.deb` f
 That is all. There is no installer, no admin prompt, and **you do not need Java** — a trimmed
 runtime is inside the folder. Keep the folder together: the `.exe` needs `runtime/` and `app/` next to it.
 
+**Prefer a real installer?** Download the `.msi` instead and double-click it. It installs for your user
+only (no admin prompt), adds a Start Menu entry and a desktop shortcut, upgrades in place when you install
+a newer version, and uninstalls from *Settings → Apps*. Same app, same settings — just managed by Windows.
+
 | | |
 | --- | --- |
 | Works on | Windows 10 / 11, 64-bit — Ubuntu users, see [below](#ubuntu) |
@@ -43,7 +48,7 @@ runtime is inside the folder. Keep the folder together: the `.exe` needs `runtim
 | Leaves behind | only its settings, under `HKEY_CURRENT_USER\Software\JavaSoft\Prefs\io\github\hideyukimori\neneclock` |
 | To remove | delete the folder (and that registry key if you want a clean slate) |
 
-**First launch: SmartScreen.** The zip is not code-signed, so Windows shows
+**First launch: SmartScreen.** Neither download is code-signed, so Windows shows
 *"Windows protected your PC"* the first time. Click **More info → Run anyway**. It only asks once.
 
 **Verify the download (optional).** Every Release carries a `.sha256` file. In PowerShell:
@@ -59,7 +64,7 @@ Compare the hash with the one in the `.sha256` file.
 The same Release carries a `.deb` for Ubuntu (and other Debian-based distributions, amd64):
 
 ```bash
-sudo apt install ./nene-clock_0.2.3_amd64.deb   # installs to /opt/nene-clock and adds a menu entry
+sudo apt install ./nene-clock_0.2.4_amd64.deb   # installs to /opt/nene-clock and adds a menu entry
 "/opt/nene-clock/bin/NeNe Clock"                  # or launch "NeNe Clock" from your app menu
 sudo apt remove nene-clock                        # to uninstall
 ```
@@ -213,8 +218,7 @@ desktop with no `DISPLAY` setup; unit tests never need a display.
 1. `jpackage` builds an **app-image** — the launcher, your jars and a runtime trimmed to the modules
    `jdeps` says you need.
 2. That folder is zipped as the **portable zip**. This is what the Release carries.
-3. On Windows the same app-image is also wrapped into an **MSI**. It is built on every tagged run and kept
-   as a workflow artifact, but it is not published until it has been tested.
+3. On Windows the same app-image is also wrapped into an **MSI**.
 4. On Linux the same app-image becomes the **`.deb`**
    ([ADR 0015](docs/adr/0015-linux-is-distributed-as-a-deb.md)).
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,6 +161,13 @@ abstract class PackageInstaller : DefaultTask() {
                 args("--win-upgrade-uuid", "ea39da0b-604d-46ab-8ac1-69d155faaec8")
                 args("--dest", out.path)
             }
+            // zip と同じ理由で名前から空白を外す。GitHub は添付名の空白をドットに変える（#72 / #86）。
+            out.listFiles { file -> file.name.endsWith(".msi") && file.name.contains(" ") }!!.forEach { file ->
+                val renamed = File(out, file.name.replace(" ", "-"))
+                if (!file.renameTo(renamed)) {
+                    throw GradleException("could not rename ${file.name} to ${renamed.name}")
+                }
+            }
         }
         // 4. .deb も同じ app-image から作る（Linux だけ・ADR 0015）。/opt/nene-clock に入り、メニューに出て、apt remove で消える。
         //    dpkg-deb と fakeroot が要る。無ければ jpackage が「どの道具か」を言って落ちる。

--- a/docs/adr/0013-windows-is-distributed-as-a-jpackage-msi.md
+++ b/docs/adr/0013-windows-is-distributed-as-a-jpackage-msi.md
@@ -44,7 +44,8 @@
 - **active**: `packageInstaller` が Linux で app-image を作り、起動できる（gate-proofs 第 20 節）
 - **active（2026-09-05・施主の実機）**: Windows ランナーで MSI ができ、施主の Windows 実機に問題なく入った。
   ネイティブの Windows 窓でちらつきが起きないことは zip 版で先に確認済み（gate-proofs 19.3）。
-  MSI は検証済みになったが、**Release に載せるかは別の判断**（いまは zip と .deb だけ・#70）
+  ⇒ 載せない理由が無くなったので、**Release には zip・MSI・.deb の 3 つを並べる**（#86）。
+  入れたい人は MSI、入れたくない人は zip（[ADR 0014](0014-a-portable-zip-sits-beside-the-msi.md)）
 - **署名はしない（施主決定 2026-09-04）。** SmartScreen の警告は出るが、「詳細情報」→「実行」で通る。
   コード署名証明書は認証局から買う（OV で年数万円・鍵はハードウェアかクラウド署名）か、
   Microsoft の Azure Trusted Signing（月額制・法人は設立 3 年以上の条件）か、Certum の OSS 向けかになる。

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.configuration-cache=false
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8
 
 # 配布物の版（jpackage の --app-version）。MSI は数字 3 つの形しか受けない。
-version=0.2.3
+version=0.2.4


### PR DESCRIPTION
Closes #86

## 何を

- Release に **zip・MSI・.deb** の 3 つを並べる（各 `.sha256` つき）
- MSI の名前から空白を外す（`NeNe-Clock-0.2.4.msi`）。GitHub は添付名の空白をドットに変える（#72 で zip は対応済み）
- README 日英に「インストーラで入れたいなら .msi」を足し、SmartScreen の注意を両方に掛かる書き方へ
- ADR 0013 の「載せるかは別の判断」を「3 つ並べる」に更新
- `version=0.2.4`

## なぜ

#70 の時点では MSI が未検証だったので Release から外していた。2026-09-05 に**施主の Windows 実機で問題なく入った**（gate-proofs 20.5・ADR 0013 は active 済み）。外しておく理由が無くなった。

## 検証

```
./gradlew check → BUILD SUCCESSFUL
./gradlew packageInstaller（Linux）→ zip と .deb。MSI と改名は Windows ランナーで走る
```

この PR の windows job が、改名した MSI が成果物に上がることの証明になる。

## 残るリスク

- MSI の改名は Linux では走らないので、手元では確かめていない（CI で確かめる）
- v0.2.3 以前の Release には MSI が無いまま。README は `/releases/latest` を指すので追随する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld7TNxmvu8ekVQyiAJPGXh