### PR TITLE
docs(readme): 日本語の手順が 4 から始まっていたのを直す

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
    It says that only because the app is not code-signed, and it asks only once.
 3. Go through the installer, then start **NeNe Clock** from the Start Menu.
 
+<!-- 🔴 この行を消さないこと。空行だけでは Markdown はリストを終えないので、
+     続く日本語の手順が 4 から始まってしまう（2026-09-05・GitHub の描画で実測）。 -->
+
 1. 落としたファイルをダブルクリックする。
 2. 青い画面で「**Windows によって PC が保護されました**」と出たら、**「詳細情報」→「実行」**を押す。
    コード署名をしていないので出るだけで、聞かれるのは最初の 1 回だけ。


### PR DESCRIPTION
## 問題

施主の指摘: README の Windows のインストール手順で、**日本語が 4 から始まる**。

**空行だけでは Markdown はリストを終えない。** 英語の手順（1〜3）に続く日本語の手順が、同じリストの 4・5・6 として描かれていた。

## 再現と確認（GitHub の描画 API で実測）

```
修正前: <ol> が 1 つ・<li> が 6 個   ← 日本語は 4 から
修正後: <ol> が 2 つ・各 3 項目      ← どちらも 1 から
```

両方の README を丸ごと描画し直して、他に同じ形が無いことも確かめた。

| | リスト1 | リスト2 | リスト3 |
| --- | --- | --- | --- |
| README.md | 英語の手順 3 | 日本語の手順 3 | 配布物の手順 4 |
| README.ja.md | 日本語の手順 3 | 配布物の手順 4 | — |

## 何を

英語の手順と日本語の手順のあいだにリスト区切りを入れた。**なぜ必要かをコメントで残した**ので、掃除のときに消されない。

## 残るリスク

なし。文書のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ld7TNxmvu8ekVQyiAJPGXh